### PR TITLE
compactarray: Remove redundant mask parameter

### DIFF
--- a/src/bits/compact_array.rs
+++ b/src/bits/compact_array.rs
@@ -82,18 +82,18 @@ impl<B> CompactArray<B> {
     /// `len` * `bit_width` must be between 0 (included) the number of
     /// bits in `data` (included).
     #[inline(always)]
-    pub unsafe fn from_raw_parts(data: B, bit_width: usize, mask: usize, len: usize) -> Self {
+    pub unsafe fn from_raw_parts(data: B, bit_width: usize, len: usize) -> Self {
         Self {
             data,
             bit_width,
-            mask,
+            mask: mask(bit_width),
             len,
         }
     }
 
     #[inline(always)]
-    pub fn into_raw_parts(self) -> (B, usize, usize, usize) {
-        (self.data, self.bit_width, self.mask, self.len)
+    pub fn into_raw_parts(self) -> (B, usize, usize) {
+        (self.data, self.bit_width, self.len)
     }
 }
 


### PR DESCRIPTION
Is there a situation where it would be different from the one we compute this way?