### PR TITLE
Fix minimum required epserde version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = "0.2.15"
 rayon = {version="1.7.0", optional=true}
 stable_deref_trait = "1.2.0"
 yoke = "0.7.1"
-epserde = "0.2.0"
+epserde = "0.2.1"
 bitvec = "1.0.1"
 clap = { version = "4.2.7", features = ["derive"] }
 dsi-progress-logger = "0.2.1"


### PR DESCRIPTION
sux 0.1.1 fails to compile with epserde 0.2.0:

```
error[E0308]: mismatched types
  --> /home/dev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sux-0.1.1/src/utils/sig_store.rs:39:10
   |
39 | #[derive(Epserde, Debug, Clone, Copy)]
   |          ^^^^^^^
   |          |
   |          expected `Result<&SigVal<<T as DeserializeInner>::DeserType<'_>>, Error>`, found `Result<&SigVal<T>, Error>`
   |          expected `Result<&'a sig_store::SigVal<<T as epserde::deser::DeserializeInner>::DeserType<'a>>, epserde::deser::Error>` because of return type
...
42 | pub struct SigVal<T: ZeroCopy + 'static> {
   |                   - this type parameter
   |
   = note: expected enum `Result<&'a sig_store::SigVal<<T as epserde::deser::DeserializeInner>::DeserType<'a>>, _>`
              found enum `Result<&sig_store::SigVal<T>, _>`
   = note: this error originates in the derive macro `Epserde` (in Nightly builds, run with -Z macro-backtrace for more info)
help: use `?` to coerce and return an appropriate `Err`, and wrap the resulting value in `Ok` so the expression remains of type `Result`
   |
39 | #[derive(Ok(Epserde?), Debug, Clone, Copy)]
   |          +++       ++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `sux` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```