### PR TITLE
Add support for epserde 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.20"
 mmap-rs = "0.6.1"
 num_cpus = "1.16.0"
 num-traits = "0.2.15"
-epserde = "0.4.0"
+epserde = ">=0.4.0,<0.6.0"
 dsi-progress-logger = "0.2.2"
 rand = {version="0.8.5", features=["small_rng"]}
 zstd = "0.13.0"


### PR DESCRIPTION
epserde's traits cross crates, which results in compilation errors when two dependents of epserde have incompatible requirements