### PR TITLE
Allow initializing `BitVec` and `AtomicBitVec` with a custom value

### DIFF
--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -90,11 +90,14 @@ impl BitVec<Vec<usize>> {
     /// Create a new bit vector of length `len` initialized to `value`.
     pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
+        let extra_bits = (n_of_words * BITS) - len;
         let word_value = if value { !0 } else { 0 };
-        Self {
-            data: vec![word_value; n_of_words],
-            len,
+        let mut data = vec![word_value; n_of_words];
+        if extra_bits > 0 {
+            let last_word_value = word_value >> extra_bits;
+            data[n_of_words - 1] = last_word_value;
         }
+        Self { data, len }
     }
 
     pub fn capacity(&self) -> usize {
@@ -144,13 +147,16 @@ impl AtomicBitVec<Vec<AtomicUsize>> {
     /// Create a new atomic bit vector of length `len` initialized to `value`.
     pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
+        let extra_bits = (n_of_words * BITS) - len;
         let word_value = if value { !0 } else { 0 };
-        Self {
-            data: (0..n_of_words)
-                .map(|_| AtomicUsize::new(word_value))
-                .collect(),
-            len,
+        let mut data = (0..n_of_words)
+            .map(|_| AtomicUsize::new(word_value))
+            .collect::<Vec<_>>();
+        if extra_bits > 0 {
+            let last_word_value = word_value >> extra_bits;
+            data[n_of_words - 1] = AtomicUsize::new(last_word_value);
         }
+        Self { data, len }
     }
 }
 

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -82,12 +82,12 @@ impl<B: AsRef<[usize]>> Index<usize> for BitVec<B> {
 }
 
 impl BitVec<Vec<usize>> {
-    /// Create a new bit vector of length `len` initialized to `false`.
+    /// Creates a new bit vector of length `len` initialized to `false`.
     pub fn new(len: usize) -> Self {
         Self::with_value(len, false)
     }
 
-    /// Create a new bit vector of length `len` initialized to `value`.
+    /// Creates a new bit vector of length `len` initialized to `value`.
     pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
         let extra_bits = (n_of_words * BITS) - len;
@@ -139,12 +139,12 @@ impl BitVec<Vec<usize>> {
 }
 
 impl AtomicBitVec<Vec<AtomicUsize>> {
-    /// Create a new atomic bit vector of length `len` initialized to `false`.
+    /// Creates a new atomic bit vector of length `len` initialized to `false`.
     pub fn new(len: usize) -> Self {
         Self::with_value(len, false)
     }
 
-    /// Create a new atomic bit vector of length `len` initialized to `value`.
+    /// Creates a new atomic bit vector of length `len` initialized to `value`.
     pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
         let extra_bits = (n_of_words * BITS) - len;

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -82,11 +82,17 @@ impl<B: AsRef<[usize]>> Index<usize> for BitVec<B> {
 }
 
 impl BitVec<Vec<usize>> {
-    /// Create a new bit vector of length `len`.
+    /// Create a new bit vector of length `len` initialized to `false`.
     pub fn new(len: usize) -> Self {
+        Self::with_value(len, false)
+    }
+
+    /// Create a new bit vector of length `len` initialized to `value`.
+    pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
+        let word_value = if value { !0 } else { 0 };
         Self {
-            data: vec![0; n_of_words],
+            data: vec![word_value; n_of_words],
             len,
         }
     }
@@ -130,11 +136,19 @@ impl BitVec<Vec<usize>> {
 }
 
 impl AtomicBitVec<Vec<AtomicUsize>> {
-    /// Create a new atomic bit vector of length `len`.
+    /// Create a new atomic bit vector of length `len` initialized to `false`.
     pub fn new(len: usize) -> Self {
+        Self::with_value(len, false)
+    }
+
+    /// Create a new atomic bit vector of length `len` initialized to `value`.
+    pub fn with_value(len: usize, value: bool) -> Self {
         let n_of_words = (len + BITS - 1) / BITS;
+        let word_value = if value { !0 } else { 0 };
         Self {
-            data: (0..n_of_words).map(|_| AtomicUsize::new(0)).collect(),
+            data: (0..n_of_words)
+                .map(|_| AtomicUsize::new(word_value))
+                .collect(),
             len,
         }
     }

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -21,6 +21,14 @@ fn test_bit_vec() {
 
     let mut rng = SmallRng::seed_from_u64(0);
 
+    let bm = BitVec::with_value(u, true);
+
+    assert_eq!(bm.len(), u);
+
+    for i in 0..u {
+        assert_eq!(bm[i], true);
+    }
+
     let mut bm = BitVec::new(u);
 
     for _ in 0..10 {
@@ -96,6 +104,14 @@ fn test_bit_vec() {
         for i in 0..u {
             assert!(!bm.get(i, Ordering::Relaxed));
         }
+    }
+
+    let bm = AtomicBitVec::with_value(u, true);
+
+    assert_eq!(bm.len(), u);
+
+    for i in 0..u {
+        assert_eq!(bm.get(i, Ordering::Relaxed), true);
     }
 }
 

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -24,6 +24,7 @@ fn test_bit_vec() {
     let bm = BitVec::with_value(u, true);
 
     assert_eq!(bm.len(), u);
+    assert_eq!(bm.count_ones(), u);
 
     for i in 0..u {
         assert_eq!(bm[i], true);
@@ -109,6 +110,7 @@ fn test_bit_vec() {
     let bm = AtomicBitVec::with_value(u, true);
 
     assert_eq!(bm.len(), u);
+    assert_eq!(bm.count_ones(), u);
 
     for i in 0..u {
         assert_eq!(bm.get(i, Ordering::Relaxed), true);

--- a/tests/test_rear_coded_list.rs
+++ b/tests/test_rear_coded_list.rs
@@ -56,7 +56,7 @@ fn test_rear_coded_list() -> Result<()> {
     }
 
     for from in 0..rca.len() {
-        for (i, word) in rca.into_iter_from(from).enumerate() {
+        for (i, word) in rca.iter_from(from).enumerate() {
             assert_eq!(word, words[i + from]);
         }
     }


### PR DESCRIPTION
This PR adds the ability to initialize `BitVec` and `AtomicBitVec` with a custom `bool` value instead of always defaulting to `false`.