### PR TITLE
Add Index impl to AtomicBitVec as a `get` shorthand

### DIFF
--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -225,6 +225,17 @@ impl<B: AsRef<[usize]>> BitVec<B> {
     }
 }
 
+impl<B: AsRef<[AtomicUsize]>> Index<usize> for AtomicBitVec<B> {
+    type Output = bool;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match self.get(index, Ordering::Relaxed) {
+            false => &false,
+            true => &true,
+        }
+    }
+}
+
 impl<B: AsRef<[AtomicUsize]>> AtomicBitVec<B> {
     /// Return the number of bits set to 1 in this bit vector.
     ///

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -228,6 +228,7 @@ impl<B: AsRef<[usize]>> BitVec<B> {
 impl<B: AsRef<[AtomicUsize]>> Index<usize> for AtomicBitVec<B> {
     type Output = bool;
 
+    /// Shorthand for [`Self::get`] using [`Ordering::Relaxed`].
     fn index(&self, index: usize) -> &Self::Output {
         match self.get(index, Ordering::Relaxed) {
             false => &false,


### PR DESCRIPTION
Index acts as a shorthand for `get` with `Ordering::Relaxed`

N.B.: the failing test is fixed in #38 