### PR TITLE
ported and optimized apply from PR #36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["succinct", "rank", "select"]
 anyhow = "1.0.79"
 bitflags = "2.4.2"
 bytemuck = "1.14.0"
-common_traits = "0.10.0"
+common_traits = "0.11.0"
 libc = "0.2.147"
 log = "0.4.20"
 num_cpus = "1.16.0"
@@ -54,6 +54,17 @@ rdst = "0.20.11"
 static_assertions = "1.1.0"
 forward-traits = "3.1.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[lib]
+bench = false
+
+[[bench]]
+name = "my_benchmarks"
+harness = false
+
+[[bench]]
+name = "apply"
+harness = false
 
 [features]
 default = ["rayon"]

--- a/benches/apply/README.md
+++ b/benches/apply/README.md
@@ -1,0 +1,9 @@
+This bench confronts the apply function with calling get and set on each value.
+To generate the data:
+```$
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench apply 2>&1 > bench_apply.log
+```
+Then to plot the values:
+```$
+python3 plot.py
+```

--- a/benches/apply/main.rs
+++ b/benches/apply/main.rs
@@ -1,0 +1,75 @@
+//! This bench compares executing a simple operation, such as increasing two values in a BitFieldVec,
+//! using either a combination of get and set or using the apply method.
+//!
+//! The expectation is that the apply method is faster than the get and set combination.
+
+use criterion::BenchmarkId;
+use criterion::{criterion_group, criterion_main, Criterion};
+use sux::bits::BitFieldVec;
+use sux::traits::BitFieldSlice;
+use sux::traits::BitFieldSliceCore;
+use sux::traits::BitFieldSliceMut;
+use sux::traits::BitFieldSliceRW;
+use sux::traits::Word;
+
+const FRACTION: usize = 1;
+const LEN: usize = 1_000_000;
+
+fn bench_apply<W: Word>(c: &mut Criterion)
+where
+    BitFieldVec<W>: BitFieldSliceCore<W> + BitFieldSliceMut<W> + BitFieldSliceRW<W>,
+{
+    let mut group = c.benchmark_group(core::any::type_name::<W>());
+    for mut bit_width in 1..=W::BITS / FRACTION {
+        group.measurement_time(std::time::Duration::from_secs(10));
+        bit_width *= FRACTION;
+        let mut bf: BitFieldVec<W> = BitFieldVec::new(bit_width as usize, LEN);
+        let mask = bf.mask();
+
+        group.bench_with_input(
+            BenchmarkId::new("get_set", bit_width),
+            &bit_width,
+            |b, _bw| {
+                b.iter(|| {
+                    for i in 0..bf.len() {
+                        unsafe {
+                            bf.set_unchecked(i, bf.get_unchecked(i).wrapping_add(W::ONE) & mask);
+                        }
+                    }
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("apply", bit_width),
+            &bit_width,
+            |b, _bw| {
+                b.iter(|| unsafe {
+                    bf.apply_inplace_unchecked(|x: W| x.wrapping_add(W::ONE) & mask);
+                });
+            },
+        );
+    }
+}
+
+fn bench_apply_u8(c: &mut Criterion) {
+    bench_apply::<u8>(c);
+}
+fn bench_apply_u16(c: &mut Criterion) {
+    bench_apply::<u16>(c);
+}
+fn bench_apply_u32(c: &mut Criterion) {
+    bench_apply::<u32>(c);
+}
+fn bench_apply_u64(c: &mut Criterion) {
+    bench_apply::<u64>(c);
+}
+
+criterion_group!(
+    benches,
+    bench_apply_u64,
+    bench_apply_u32,
+    bench_apply_u16,
+    bench_apply_u8,
+);
+
+criterion_main!(benches);

--- a/benches/apply/plot.py
+++ b/benches/apply/plot.py
@@ -1,0 +1,148 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import re
+
+# We load up the benchmark file with the Criterion benchmark results
+benchmark = open("bench_apply.log", "r").read()
+
+# We split the file into lines and keep only the lines containing 'time:'
+lines = benchmark.split("\n")
+
+# We create a list of dictionaries, each dictionary containing the benchmark results for one function
+results = []
+
+uom = {
+    "ps": 1e-12,
+    "ns": 1e-9,
+    "µs": 1e-6,
+    "ms": 1e-3,
+    "s": 1,
+}
+uom_str = "("+"|".join(uom.keys())+")"
+
+r = re.compile(r"(?P<word>u\d+)/(?P<name>\S+)/(?P<window>\d+)\s+time:\s+\[(?P<lower>\d+\.\d+)\s+(?P<lower_uom>{uom})\s+(?P<average>\d+\.\d+)\s+(?P<average_uom>{uom})\s+(?P<upper>\d+\.\d+)\s+(?P<upper_uom>{uom})\]".format(uom=uom_str))
+
+for line in lines:
+    if "time:" not in line:
+        continue
+    
+    match = next(m.groupdict() for m in r.finditer(line))
+
+    # We add the results to the list
+    results.append({
+        "name": match["name"],
+        "word": match["word"],
+        "window": int(match["window"]),
+        "lower"  : float(match["lower"]) * uom[match["lower_uom"]] * 1e6,
+        "average": float(match["average"]) * uom[match["average_uom"]] * 1e6,
+        "upper"  : float(match["upper"]) * uom[match["upper_uom"]] * 1e6,
+    })
+
+# We create a DataFrame from the list of dictionaries
+df = pd.DataFrame(results)
+
+# We create a new dataframe with the name of the function combined with the time
+# columns so to better display and compare the results in a human readable way
+apply_df = df[df["name"] == "apply"].drop(columns=["name"])
+luca_df = df[df["name"] == "luca"].drop(columns=["name"])
+get_set_df = df[df["name"] == "get/set"].drop(columns=["name"])
+
+apply_df.columns = ["word", "window", "lower_apply", "average_apply", "upper_apply"]
+luca_df.columns = ["word", "window", "lower_apply", "average_apply", "upper_apply"]
+get_set_df.columns = ["word", "window", "lower_get_set", "average_get_set", "upper_get_set"]
+# We sort both dataframes by word and window
+apply_df = apply_df.sort_values(by=["word", "window"])
+luca_df = apply_df.sort_values(by=["word", "window"])
+get_set_df = get_set_df.sort_values(by=["word", "window"])
+# We drop the word and window columns from the get_set_df
+get_set_df = get_set_df.drop(columns=["word", "window"])
+
+human_df = pd.concat([
+    apply_df.reset_index(drop=True),
+    luca_df.reset_index(drop=True),
+    get_set_df.reset_index(drop=True)
+], axis=1)
+
+human_df.to_csv("bench_apply.csv", index=False)
+
+human_df
+
+
+fig, ax = plt.subplots(1, 1, figsize=(14, 8), dpi=150)
+
+# We make vertical lines at 8, 16, 32 and 64 to highlight the window sizes
+# matching with the word sizes
+ax.axvline(8, color="black", linestyle=":", alpha=0.5)
+ax.axvline(16, color="black", linestyle=":", alpha=0.5)
+ax.axvline(32, color="black", linestyle=":", alpha=0.5)
+ax.axvline(64, color="black", linestyle=":", alpha=0.5)
+# We display the size of the word sizes on the x-axis
+ax.set_xticks([4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64])
+ax.set_xticklabels(["4", "u8", "12", "u16", "20", "24", "28", "u32", "36", "40", "44", "48", "52", "56", "60", "u64"])
+
+for name in df.name.unique():
+    for word in reversed(sorted(df.word.unique())):
+        
+        subdf = df[(df.name == name) & (df.word == word)]
+        # We sort the values by the window size
+        subdf = subdf.sort_values("window")
+
+        # We color the area above and below the average time
+        area = ax.fill_between(subdf.window, y1=subdf.lower, y2=subdf.upper, alpha=1)
+
+        # We plot the average time using the same color as per the area
+        ax.plot(
+            subdf.window,
+            subdf.average,
+            label=f"{name} {word}",
+            color=area.get_facecolor()[0],
+            alpha=1.0,
+            linestyle="-",
+        )
+
+ax.set_xlabel("Window size")
+ax.legend(ncol=2)
+ax.set_ylabel("Time (µs)")
+ax.set_title("Absolute time")
+fig.tight_layout()
+# We save the plot to a file
+plt.savefig("bench_apply.jpg")
+
+fig, ax = plt.subplots(1, 1, figsize=(14, 8), dpi=150)
+
+# We make vertical lines at 8, 16, 32 and 64 to highlight the window sizes
+# matching with the word sizes
+ax.axvline(8, color="black", linestyle=":", alpha=0.5)
+ax.axvline(16, color="black", linestyle=":", alpha=0.5)
+ax.axvline(32, color="black", linestyle=":", alpha=0.5)
+ax.axvline(64, color="black", linestyle=":", alpha=0.5)
+# We display the size of the word sizes on the x-axis
+ax.set_xticks([4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64])
+ax.set_xticklabels(["4", "u8", "12", "u16", "20", "24", "28", "u32", "36", "40", "44", "48", "52", "56", "60", "u64"])
+
+for name in df.name.unique():
+    for word in reversed(sorted(df.word.unique())):
+        
+        subdf = df[(df.name == name) & (df.word == word)]
+        # We sort the values by the window size
+        subdf = subdf.sort_values("window")
+
+        # We color the area above and below the average time
+        area = ax.fill_between(subdf.window, y1=subdf.lower/ 1_000, y2=subdf.upper/ 1_000, alpha=1)
+
+        # We plot the average time using the same color as per the area
+        ax.plot(
+            subdf.window,
+            subdf.average/ 1_000,
+            label=f"{name} {word}",
+            color=area.get_facecolor()[0],
+            alpha=1.0,
+            linestyle="-",
+        )
+
+ax.set_xlabel("Window size")
+ax.legend(ncol=2)
+ax.set_ylabel("ns / element")
+fig.tight_layout()
+# We save the plot to a file
+plt.savefig("bench_apply_per_element.jpg")

--- a/src/rank_sel/select9.rs
+++ b/src/rank_sel/select9.rs
@@ -13,7 +13,7 @@ use crate::{
     traits::{BitLength, NumBits, Select},
 };
 use ambassador::Delegate;
-use common_traits::{SelectInWord, Sequence};
+use common_traits::SelectInWord;
 use epserde::Epserde;
 use mem_dbg::{MemDbg, MemSize};
 
@@ -412,15 +412,11 @@ impl<B: AsRef<[usize]> + BitLength, C: AsRef<[BlockCounters]>, I: AsRef<[usize]>
                 debug_assert!(rank_in_block < 512);
             }
             128..=255 => {
-                let (_, s, _) = subinv_ref
-                    .get_range_unchecked(subinv_pos..self.subinventory_size)
-                    .align_to::<u16>();
+                let (_, s, _) = subinv_ref[subinv_pos..self.subinventory_size].align_to::<u16>();
                 return *s.get_unchecked(rank % Self::ONES_PER_INVENTORY) as usize + inventory_left;
             }
             256..=511 => {
-                let (_, s, _) = subinv_ref
-                    .get_range_unchecked(subinv_pos..self.subinventory_size)
-                    .align_to::<u32>();
+                let (_, s, _) = subinv_ref[subinv_pos..self.subinventory_size].align_to::<u32>();
                 return *s.get_unchecked(rank % Self::ONES_PER_INVENTORY) as usize + inventory_left;
             }
             _ => {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -16,6 +16,7 @@ pub use bit_field_slice::BitFieldSlice;
 pub use bit_field_slice::BitFieldSliceCore;
 pub use bit_field_slice::BitFieldSliceIterator;
 pub use bit_field_slice::BitFieldSliceMut;
+pub use bit_field_slice::BitFieldSliceRW;
 pub use bit_field_slice::Word;
 
 pub mod indexed_dict;


### PR DESCRIPTION
This PR ports the `apply_inplace` function from PR #36.
While this is no new functionality, it's, on average 4 times faster than the naive implementation, as seen in the benchmark graph:

![bench_apply_per_element](https://github.com/vigna/sux-rs/assets/25117939/757f9eaf-dfac-41a7-94b6-f263242206f8)

*Window size is actually bit_width*