### PR TITLE
Allow access to BitFieldVec backend and fix reset_atomic

### DIFF
--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -924,6 +924,12 @@ impl<W: Word + IntoAtomic, B> AtomicBitFieldVec<W, B> {
     pub fn into_raw_parts(self) -> (B, usize, usize) {
         (self.bits, self.bit_width, self.len)
     }
+
+    /// Return the mask used to extract values from this vector.
+    /// This will keep the lowest `bit_width` bits.
+    pub fn mask(&self) -> W {
+        self.mask
+    }
 }
 
 impl<W: Word + IntoAtomic> AtomicBitFieldVec<W>
@@ -942,43 +948,16 @@ where
             len,
         }
     }
+}
 
+impl<W: Word + IntoAtomic, B: AsRef<[W::AtomicType]>> AtomicBitFieldVec<W, B>
+where
+    W::AtomicType: AtomicUnsignedInt + AsBytes,
+{
     /// Writes zeros in all values.
+    #[deprecated(since = "0.4.4", note = "reset is deprecated in favor of reset_atomic")]
     pub fn reset(&mut self, ordering: Ordering) {
-        let bit_len = self.len * self.bit_width;
-        let full_words = bit_len / W::BITS;
-        let residual = bit_len % W::BITS;
-        let bits: &[W::AtomicType] = self.bits.as_ref();
-
-        #[cfg(feature = "rayon")]
-        {
-            bits[..full_words]
-                .par_iter()
-                .for_each(|x| x.store(W::ZERO, ordering));
-        }
-
-        #[cfg(not(feature = "rayon"))]
-        {
-            bits[..full_words]
-                .iter()
-                .for_each(|x| x.store(W::ZERO, ordering));
-        }
-
-        if residual != 0 {
-            bits[full_words].fetch_and(W::MAX << residual, ordering);
-        }
-    }
-
-    /// Return the bit-width of the values inside this vector.
-    pub fn bit_width(&self) -> usize {
-        debug_assert!(self.bit_width <= W::BITS);
-        self.bit_width
-    }
-
-    /// Return the mask used to extract values from this vector.
-    /// This will keep the lowest `bit_width` bits.
-    pub fn mask(&self) -> W {
-        self.mask
+        self.reset_atomic(ordering)
     }
 }
 
@@ -1101,6 +1080,7 @@ where
         }
     }
 
+    /// Writes zeros in all values.
     fn reset_atomic(&mut self, ordering: Ordering) {
         let bit_len = self.len * self.bit_width;
         let full_words = bit_len / W::BITS;

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -253,6 +253,18 @@ impl<W: Word, B: AsRef<[W]>> BitFieldVec<W, B> {
         let word = core::ptr::read_unaligned(ptr);
         (word >> (start_bit % 8)) & self.mask
     }
+
+    /// Returns the backend of the `BitFieldVec` as a slice of `W`.
+    pub fn as_slice(&self) -> &[W] {
+        self.bits.as_ref()
+    }
+}
+
+impl<W: Word, B: AsMut<[W]>> BitFieldVec<W, B> {
+    /// Returns the backend of the `BitFieldVec` as a mutable slice of `W`.
+    pub fn as_mut_slice(&mut self) -> &mut [W] {
+        self.bits.as_mut()
+    }
 }
 
 impl<W: Word> BitFieldVec<W, Vec<W>> {
@@ -929,6 +941,14 @@ impl<W: Word + IntoAtomic, B> AtomicBitFieldVec<W, B> {
     /// This will keep the lowest `bit_width` bits.
     pub fn mask(&self) -> W {
         self.mask
+    }
+}
+
+impl<W: Word + IntoAtomic, B: AsRef<[W::AtomicType]>> AtomicBitFieldVec<W, B> {
+    /// Returns the backend of the `AtomicBitFieldVec` as a slice of `A`, where `A` is the
+    /// atomic variant of `W`.
+    pub fn as_slice(&self) -> &[W::AtomicType] {
+        self.bits.as_ref()
     }
 }
 

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -418,7 +418,7 @@ fn test_atomic_reset() {
     for i in 0..10 {
         b.set_atomic(i, 1, Ordering::Relaxed);
     }
-    b.reset(Ordering::Relaxed);
+    b.reset_atomic(Ordering::Relaxed);
     for i in 0..10 {
         assert_eq!(b.get_atomic(i, Ordering::Relaxed), 0);
     }


### PR DESCRIPTION
This PR allows access to the backend of BitFieldVec and AtomicBitFieldVec if it implements `AsRef<[W]>`.
This could be useful if sometimes you need the ease of use of BitFieldVec and if sometimes you need the performance of word-by-word operations.

This PR also relaxes the bounds on some methods of AtomicBitFieldVec like `reset` and `bit_width`