### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `sux`
 
 [![downloads](https://img.shields.io/crates/d/sux)](https://crates.io/crates/sux)
-[![dependents](https://img.shields.io/librariesio/dependents/cargo/sux)](https://crates.io/crates/sux/reverse_dependencies)
+[![dependents](https://dependents.info/vigna/sux-rs/badge?id=UGFja2FnZS0zNjgwNjY4NDg2)](https://dependents.info/vigna/sux-rs?id=UGFja2FnZS0zNjgwNjY4NDg2)
 ![GitHub CI](https://github.com/vigna/sux-rs/actions/workflows/rust.yml/badge.svg)
 ![license](https://img.shields.io/crates/l/sux)
 [![Line count](https://tokei.rs/b1/github/vigna/sux-rs?type=Rust,Python)](https://github.com/vigna/sux-rs)
@@ -28,6 +28,12 @@ The focus is on efficiency (in particular, there are unchecked versions of all
 methods) and on flexible composability (e.g., you can fine-tune your Elias–Fano
 instance by choosing different types of internal indices, and whether to index
 zeros or ones).
+
+## Used by
+
+<a href="https://dependents.info/vigna/sux-rs?id=UGFja2FnZS0zNjgwNjY4NDg2">
+  <img src="https://dependents.info/vigna/sux-rs/image?id=UGFja2FnZS0zNjgwNjY4NDg2" />
+</a>
 
 ## ε-serde support
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR updates the crates based shields.io dependents badge to github network dependents based badge. I've also added an the image in the `README.md` file to showcase its impact.

Since this project can be depended upon by other repositories instead of just crates- it makes more sense to base that information off of github generated dependents data.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="684" alt="image" src="https://github.com/user-attachments/assets/2160cf0f-a472-4e6f-9e3a-f4fca8270bb4" />

(your project has 25 dependents, while crates based shields.io badge shows only 13)

Please feel free to close the PR if you don't want to have this!