### PR TITLE
Test --no-default-features and more Rust versions on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,14 +12,36 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0
+          - stable
+          - beta
+          - nightly
+        features:
+          - ''
+          - '--no-default-features'
+
+    steps:
+      - name: Install rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run clippy
         run: cargo clippy
-      - name: Build
-        run: cargo build --verbose
 
   coverage:
     needs: build


### PR DESCRIPTION
I included 1.85 in particular because it's the version in Debian 13, and we are going to target that in SWH, at least for code that we expect users to run.

Cargo 1.84 added a MSRV-aware dependency resolver, so hopefully this will make the Rust compiler in Debian finally usable for the lifetime of Debian releases.