### PR TITLE
Implement Copy for EliasFano

### DIFF
--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -164,7 +164,7 @@ macro_rules! bit_field_vec {
 }
 
 /// A vector of bit fields of fixed width.
-#[derive(Epserde, Debug, Clone, Hash, MemDbg, MemSize, value_traits::Subslices)]
+#[derive(Epserde, Debug, Clone, Copy, Hash, MemDbg, MemSize, value_traits::Subslices)]
 #[value_traits_subslices(bound = "B: AsRef<[W]>")]
 #[derive(value_traits::SubslicesMut)]
 #[value_traits_subslices_mut(bound = "B: AsRef<[W]> + AsMut<[W]>")]

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -167,7 +167,7 @@ macro_rules! panic_if_out_of_bounds {
     };
 }
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize)]
 /// A bit vector.
 pub struct BitVec<B = Vec<usize>> {
     bits: B,

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -206,7 +206,7 @@ use std::borrow::Borrow;
 /// assert_eq!(ef.get(1), 2);
 /// ```
 
-#[derive(Epserde, Debug, Clone, Hash, MemDbg, MemSize, value_traits::Subslices)]
+#[derive(Epserde, Debug, Clone, Copy, Hash, MemDbg, MemSize, value_traits::Subslices)]
 #[value_traits_subslices(bound = "H: AsRef<[usize]> + SelectUnchecked")]
 #[value_traits_subslices(bound = "L: BitFieldSlice<usize>")]
 pub struct EliasFano<H = BitVec<Box<[usize]>>, L = BitFieldVec<usize, Box<[usize]>>> {

--- a/src/rank_sel/rank9.rs
+++ b/src/rank_sel/rank9.rs
@@ -68,7 +68,7 @@ use std::ops::Index;
 /// assert_eq!(rank9[7], true);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitLength, target = "bits")]

--- a/src/rank_sel/rank_small.rs
+++ b/src/rank_sel/rank_small.rs
@@ -115,7 +115,7 @@ pub trait SmallCounters<const NUM_U32S: usize, const COUNTER_WIDTH: usize> {
 /// assert_eq!(rank_small[5], true);
 /// assert_eq!(rank_small[6], false);
 /// assert_eq!(rank_small[7], true);
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitLength, target = "bits")]

--- a/src/rank_sel/select9.rs
+++ b/src/rank_sel/select9.rs
@@ -114,7 +114,7 @@ use std::ops::Index;
 /// assert_eq!(select9[7], true);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "rank9")]
 #[delegate(Index<usize>, target = "rank9")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "rank9")]

--- a/src/rank_sel/select_adapt.rs
+++ b/src/rank_sel/select_adapt.rs
@@ -207,7 +207,7 @@ use std::ops::Index;
 /// assert_eq!(rank9_sel[7], true);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "bits")]

--- a/src/rank_sel/select_adapt_const.rs
+++ b/src/rank_sel/select_adapt_const.rs
@@ -141,7 +141,7 @@ use std::ops::Index;
 /// assert_eq!(rank9_sel[7], true);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "bits")]

--- a/src/rank_sel/select_small.rs
+++ b/src/rank_sel/select_small.rs
@@ -102,7 +102,7 @@ use std::ops::Index;
 /// assert_eq!(sel.select_zero(2), Some(6));
 /// assert_eq!(sel.select_zero(3), None);
 /// ```
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "small_counters")]
 #[delegate(Index<usize>, target = "small_counters")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "small_counters")]

--- a/src/rank_sel/select_zero_adapt.rs
+++ b/src/rank_sel/select_zero_adapt.rs
@@ -126,7 +126,7 @@ use std::ops::Index;
 /// assert_eq!(rank9_sel[7], false);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "bits")]

--- a/src/rank_sel/select_zero_adapt_const.rs
+++ b/src/rank_sel/select_zero_adapt_const.rs
@@ -125,7 +125,7 @@ use std::ops::Index;
 /// assert_eq!(rank9_sel[7], false);
 /// ```
 
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "bits")]
 #[delegate(Index<usize>, target = "bits")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "bits")]

--- a/src/rank_sel/select_zero_small.rs
+++ b/src/rank_sel/select_zero_small.rs
@@ -70,7 +70,7 @@ use std::ops::Index;
 /// assert_eq!(sel.select(2), Some(6));
 /// assert_eq!(sel.select(3), None);
 /// ```
-#[derive(Epserde, Debug, Clone, MemDbg, MemSize, Delegate)]
+#[derive(Epserde, Debug, Clone, Copy, MemDbg, MemSize, Delegate)]
 #[delegate(AsRef<[usize]>, target = "small_counters")]
 #[delegate(Index<usize>, target = "small_counters")]
 #[delegate(crate::traits::rank_sel::BitCount, target = "small_counters")]


### PR DESCRIPTION
Motivation:

I have this struct:

```
pub struct SubgraphWccsState<
    N: MonotoneContractionBackend = EfSeqDict,
    S = Sccs<Box<[usize]>>,
> {
    contraction_backend: N,
    sccs: S,
    graph_path_hint: String,
}

impl<
    N: MonotoneContractionBackend + Copy,
    C: AsRef<[NodeId]> + Copy,
> Clone for SubgraphWccsState<N, Sccs<C>> {
    fn clone (&self) -> Self {
        Self {
            contraction_backend: self.contraction_backend,
            sccs: self.sccs,
            graph_path_hint: self.graph_path_hint.clone(),
        }
    }
}
```

(`MonotoneContractionBackend` is a trait implemented by EliasFano)

It implements `Clone` only when backed by copy types because I want to avoid accidentally expensive copies clones when it's backed by `Box<[_]>` instead of `&[_]`.