### PR TITLE
Refactor unit tests to use anyhow::Result

### DIFF
--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -437,7 +437,7 @@ fn test_eq() {
 }
 
 #[test]
-fn test_epserde() {
+fn test_epserde() -> anyhow::Result<()> {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut b = BitVec::new(200);
     for i in 0..200 {
@@ -445,16 +445,16 @@ fn test_epserde() {
     }
 
     let tmp_file = std::env::temp_dir().join("test_serdes_ef.bin");
-    let mut file = std::io::BufWriter::new(std::fs::File::create(&tmp_file).unwrap());
-    unsafe { b.serialize(&mut file) }.unwrap();
+    let mut file = std::io::BufWriter::new(std::fs::File::create(&tmp_file)?);
+    unsafe { b.serialize(&mut file) }?;
     drop(file);
 
-    let c =
-        unsafe { <BitVec<Vec<usize>>>::mmap(&tmp_file, epserde::deser::Flags::empty()).unwrap() };
+    let c = unsafe { <BitVec<Vec<usize>>>::mmap(&tmp_file, epserde::deser::Flags::empty())? };
 
     for i in 0..200 {
         assert_eq!(b.get(i), c.uncase().get(i));
     }
+    Ok(())
 }
 
 #[test]

--- a/tests/test_rear_coded_list.rs
+++ b/tests/test_rear_coded_list.rs
@@ -24,10 +24,10 @@ fn test_rear_coded_list_100() -> Result<()> {
 }
 
 fn test_rear_coded_list(path: impl AsRef<str>) -> Result<()> {
-    let words = BufReader::new(std::fs::File::open(path.as_ref()).unwrap())
+    let words = BufReader::new(std::fs::File::open(path.as_ref())?)
         .lines()
-        .map(|line| line.unwrap())
-        .collect::<Vec<_>>();
+        .map(|line| line.map_err(anyhow::Error::from))
+        .collect::<Result<Vec<_>>>()?;
 
     // test sorted RCL
 


### PR DESCRIPTION
The unit tests in the `tests` directory have been refactored to use `anyhow::Result` and the `?` operator instead of `.unwrap()`.

This makes the tests more robust by propagating errors instead of panicking.

Only tests that contain fallible operations have been modified.