### PR TITLE
Check for overflows in EliasFanoBuilder::new()

### DIFF
--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -818,6 +818,10 @@ pub struct EliasFanoBuilder {
 impl EliasFanoBuilder {
     /// Creates a builder for an [`EliasFano`] containing
     /// `n` numbers smaller than or equal to `u`.
+    ///
+    /// # Panic
+    ///
+    /// When any of the underlying structures would exceed `usize` in length.
     pub fn new(n: usize, u: usize) -> Self {
         let l = if u >= n {
             (u as f64 / n as f64).log2().floor() as usize
@@ -825,17 +829,21 @@ impl EliasFanoBuilder {
             0
         };
 
+        let num_high_bits = n
+            .checked_add(1)
+            .expect(&format!("n ({n}) is too large"))
+            .checked_add(u >> l)
+            .expect(&format!("n ({n}) and/or u ({u}) is too large"));
         Self {
             n,
             u,
             l,
             low_bits: BitFieldVec::new(l, n),
-            high_bits: BitVec::new(n + (u >> l) + 1),
+            high_bits: BitVec::new(num_high_bits),
             last_value: 0,
             count: 0,
         }
     }
-
     /// Adds a new value to the builder.
     ///
     /// # Panic


### PR DESCRIPTION
Otherwise, user code can be hard to debug. For example, this code:

```rust
use sux::prelude::*;

fn main() {
    let n = 0usize.wrapping_sub(122);
    let mut efb = EliasFanoBuilder::new(n, 137192512).unwrap();

    println!("writing ok values");
    for _ in 0..7075686 {
        efb.push(1);
    }
    println!("writing troublesome value");
    efb.push(130118655);
    println!("all went well");
}
```

results in this error in release mode:

```
writing ok values
writing troublesome value

thread 'main' panicked at src/bits/bit_vec.rs:248:9:
Bit index out of bounds: 137194341 >= 137192391
```

or this in debug mode:

```
thread 'main' panicked at src/dict/elias_fano.rs:833:36:
attempt to add with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```