### PR TITLE
Fix dependency constraint on epserde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.20"
 dsi-progress-logger = "0.8.1"
 tempfile = "3.9.0"
 lender = "0.4.0"
-epserde = { version = "0.11.0", optional = true }
+epserde = { version = "0.11.3", optional = true }
 zstd = { version = "0.13.1" }
 flate2 = "1.0.28"
 rand = { version = "0.9.0", features = ["small_rng"] }


### PR DESCRIPTION
sux does not compile with epserde 0.11.0:

```
    Checking sux v0.9.1 (/home/dev/sux-rs)
error[E0599]: the method `serialize` exists for struct `Struct<SerIter<'_, &str, WritingIter<'_, Iter<'_, &str>>>, Box<Vec<usize>>>`, but its trait bounds were not satisfied
   --> tests/test_rear_coded_list.rs:225:20
    |
178 |         struct Struct<S, L> {
    |         ------------------- method `serialize` not found for this struct because it doesn't satisfy `_: SerInner` or `_: Serialize`
...
225 |         unsafe { s.serialize(&mut cursor).unwrap() };
    |                    ^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
   ::: /home/dev/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/epserde-0.11.0/src/impls/iter.rs:30:1
    |
30  | pub struct SerIter<'a, T: 'a, I: ExactSizeIterator<Item = &'a T>>(RefCell<I>);
    | ----------------------------------------------------------------- doesn't satisfy `_: SerHelper<_>` or `_: SerInner`
    |
    = note: trait bound `SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>: SerInner` was not satisfied
    = note: the following trait bounds were not satisfied:
            `Struct<SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>, Box<Vec<usize>>>: SerInner`
            which is required by `Struct<SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>, Box<Vec<usize>>>: Serialize`
            `&str: CopyType`
            which is required by `Struct<SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>, Box<Vec<usize>>>: Serialize`
            `SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>: SerHelper<_>`
            which is required by `Struct<SerIter<'_, &str, WritingIter<'_, std::slice::Iter<'_, &str>>>, Box<Vec<usize>>>: Serialize`
note: the trait `SerInner` must be implemented
   --> /home/dev/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/epserde-0.11.0/src/ser/mod.rs:130:1
    |
130 | pub trait SerInner {
    | ^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `serialize`, perhaps you need to implement one of them:
            candidate #1: `Serialize`
            candidate #2: `serde_core::ser::Serialize`
```