### PR TITLE
Add PartialValueArray

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: 2025 Inria
  * SPDX-FileCopyrightText: 2024 Sebastiano Vigna
  *
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
@@ -9,7 +10,49 @@
 //! This module provides array-like data structures with specialized
 //! characteristics for succinct data structure applications.
 
+use mem_dbg::*;
+
+use crate::bits::BitVec;
+use crate::dict::elias_fano::EliasFano;
+use crate::rank_sel::{Rank9, SelectZeroAdaptConst};
+use crate::traits::SuccUnchecked;
+
 pub mod partial_array;
 pub use partial_array::{PartialArray, PartialArrayBuilder, new_dense, new_sparse};
 pub mod partial_value_array;
 pub use partial_value_array::{PartialValueArray, PartialValueArrayBuilder};
+
+/// An internal index for sparse partial arrays.
+///
+/// We cannot use directly an [Elias–Fano](crate::dict::EliasFano) structure
+/// because we need to keep track of the first invalid position; and we need to
+/// keep track of the first invalid position because we want to implement just
+/// [`SuccUnchecked`](crate::traits::SuccUnchecked) on the Elias–Fano structure,
+/// because it requires just
+/// [`SelectZeroUnchecked`](crate::traits::SelectZeroUnchecked), whereas
+/// [`Succ`](crate::traits::Succ) would require
+/// [`SelectUnchecked`](crate::traits::SelectUnchecked) as well.
+#[doc(hidden)]
+#[derive(Debug, Clone, MemDbg, MemSize)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SparseIndex<D> {
+    ef: EliasFano<SelectZeroAdaptConst<BitVec<D>, D, 12, 3>>,
+    /// self.ef should be not be queried for values >= self.first_invalid_position
+    first_invalid_pos: usize,
+}
+
+impl<D: AsRef<[usize]>> SparseIndex<D> {
+    /// Given a `position`, returns the first `(index, position2)` with `position2 >= position`
+    ///
+    fn get_next_pos(&self, position: usize) -> Option<(usize, usize)> {
+        if position >= self.first_invalid_pos {
+            return None;
+        }
+
+        // SAFETY: we just checked it
+        Some(unsafe { self.ef.succ_unchecked::<false>(position) })
+    }
+}
+
+type DenseIndex = Rank9<BitVec<Box<[usize]>>>;

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -11,3 +11,5 @@
 
 pub mod partial_array;
 pub use partial_array::{PartialArray, PartialArrayBuilder, new_dense, new_sparse};
+pub mod partial_value_array;
+pub use partial_value_array::{PartialValueArray, PartialValueArrayBuilder};

--- a/src/array/partial_value_array.rs
+++ b/src/array/partial_value_array.rs
@@ -17,33 +17,13 @@ use value_traits::slices::SliceByValue;
 use crate::bits::BitFieldVec;
 use crate::bits::BitVec;
 use crate::dict::EliasFanoBuilder;
-use crate::dict::elias_fano::EliasFano;
-use crate::rank_sel::{Rank9, SelectZeroAdaptConst};
+use crate::panic_if_out_of_bounds;
+use crate::rank_sel::Rank9;
+use crate::traits::RankUnchecked;
 use crate::traits::Word;
 use crate::traits::{BitVecOps, BitVecOpsMut};
-use crate::traits::{RankUnchecked, SuccUnchecked};
 
-/// An internal index for sparse partial arrays.
-///
-/// We cannot use directly an [Elias–Fano](crate::dict::EliasFano) structure
-/// because we need to keep track of the first invalid position; and we need to
-/// keep track of the first invalid position because we want to implement just
-/// [`SuccUnchecked`](crate::traits::SuccUnchecked) on the Elias–Fano structure,
-/// because it requires just
-/// [`SelectZeroUnchecked`](crate::traits::SelectZeroUnchecked), whereas
-/// [`Succ`](crate::traits::Succ) would require
-/// [`SelectUnchecked`](crate::traits::SelectUnchecked) as well.
-#[doc(hidden)]
-#[derive(Debug, Clone, MemDbg, MemSize)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SparseIndex<D> {
-    ef: EliasFano<SelectZeroAdaptConst<BitVec<D>, D, 12, 3>>,
-    /// self.ef should be not be queried for values >= self.first_invalid_position
-    first_invalid_pos: usize,
-}
-
-type DenseIndex = Rank9<BitVec<Box<[usize]>>>;
+use super::{DenseIndex, SparseIndex};
 
 /// Builder for creating an immutable partial array.
 ///
@@ -320,13 +300,8 @@ impl<T: Clone, V: SliceByValue<Value = T>> PartialValueArray<T, DenseIndex, V> {
     /// assert_eq!(array.get(6), None);
     /// ```
     pub fn get(&self, position: usize) -> Option<T> {
-        if position >= self.len() {
-            panic!(
-                "Position {} is out of bounds for array of len {}",
-                position,
-                self.len()
-            );
-        }
+        panic_if_out_of_bounds!(position, self.len());
+
         // Check if there's a value at this position
         // SAFETY: position < len()
         if !unsafe { self.index.get_unchecked(position) } {
@@ -377,25 +352,15 @@ impl<T: Clone, D: AsRef<[usize]>, V: SliceByValue<Value = T>>
     /// assert_eq!(array.get(6), None);
     /// ```
     pub fn get(&self, position: usize) -> Option<T> {
-        if position >= self.index.first_invalid_pos {
-            if position >= self.len() {
-                panic!(
-                    "Position {} is out of bounds for array of len {}",
-                    position,
-                    self.len()
-                );
-            }
-            return None;
-        }
-        // Check if there's a value at this position
-        // SAFETY: position <= last set position
-        let (index, pos) = unsafe { self.index.ef.succ_unchecked::<false>(position) };
+        panic_if_out_of_bounds!(position, self.len());
+
+        let (value_index, pos) = self.index.get_next_pos(position)?;
 
         if pos != position {
             None
         } else {
             // SAFETY: necessarily value_index < num values.
-            Some(unsafe { self.values.get_value_unchecked(index) })
+            Some(unsafe { self.values.get_value_unchecked(value_index) })
         }
     }
 }

--- a/src/array/partial_value_array.rs
+++ b/src/array/partial_value_array.rs
@@ -216,7 +216,9 @@ impl<T: Clone> PartialValueArrayBuilder<T, EliasFanoBuilder> {
     }
 
     /// Builds the immutable sparse partial array using [`BitFieldVec`] as backend.
-    pub fn build_bitfieldvec(self) -> PartialValueArray<T, SparseIndex<Box<[usize]>>, BitFieldVec<T>>
+    pub fn build_bitfieldvec(
+        self,
+    ) -> PartialValueArray<T, SparseIndex<Box<[usize]>>, BitFieldVec<T>>
     where
         T: Word,
     {
@@ -340,7 +342,9 @@ impl<T: Clone, V: SliceByValue<Value = T>> PartialValueArray<T, DenseIndex, V> {
     }
 }
 
-impl<T: Clone, D: AsRef<[usize]>, V: SliceByValue<Value = T>> PartialValueArray<T, SparseIndex<D>, V> {
+impl<T: Clone, D: AsRef<[usize]>, V: SliceByValue<Value = T>>
+    PartialValueArray<T, SparseIndex<D>, V>
+{
     /// Returns the total length of the array.
     ///
     /// This is the length that was specified when creating the builder,

--- a/tests/test_partial_array.rs
+++ b/tests/test_partial_array.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+use sux::array::SparseIndex;
 use sux::array::partial_array;
 
 #[test]
@@ -175,11 +176,8 @@ fn test_serialize() {
     cursor.set_position(0);
     let array2 = unsafe {
         use epserde::deser::Deserialize;
-        <partial_array::PartialArray<u32, partial_array::SparseIndex<Box<[usize]>>>>::read_mem(
-            &mut cursor,
-            len,
-        )
-        .expect("Could not deserialize")
+        <partial_array::PartialArray<u32, SparseIndex<Box<[usize]>>>>::read_mem(&mut cursor, len)
+            .expect("Could not deserialize")
     };
     let array2 = array2.uncase();
 

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use sux::array::partial_value_array;
+
+#[test]
+fn test_empty_array() {
+    let builder = partial_value_array::new_sparse::<u32>(0, 0);
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 0);
+    assert!(array.is_empty());
+    assert_eq!(array.num_values(), 0);
+
+    let builder = partial_value_array::new_dense::<u32>(0);
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 0);
+    assert!(array.is_empty());
+    assert_eq!(array.num_values(), 0);
+}
+
+#[test]
+fn test_basic_operations() {
+    let mut builder = partial_value_array::new_sparse(10, 3);
+
+    builder.set(1, 123u32);
+    builder.set(2, 45678);
+    builder.set(7, 90);
+
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 10);
+    assert_eq!(array.num_values(), 3);
+
+    assert_eq!(array.get(0), None);
+    assert_eq!(array.get(1), Some(123));
+    assert_eq!(array.get(2), Some(45678));
+    assert_eq!(array.get(3), None);
+    assert_eq!(array.get(4), None);
+    assert_eq!(array.get(5), None);
+    assert_eq!(array.get(6), None);
+    assert_eq!(array.get(7), Some(90));
+    assert_eq!(array.get(8), None);
+    assert_eq!(array.get(9), None);
+
+    let mut builder = partial_value_array::new_dense(10);
+
+    builder.set(1, 123u32);
+    builder.set(2, 45678);
+    builder.set(7, 90);
+
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 10);
+    assert_eq!(array.num_values(), 3);
+
+    assert_eq!(array.get(0), None);
+    assert_eq!(array.get(1), Some(123));
+    assert_eq!(array.get(2), Some(45678));
+    assert_eq!(array.get(3), None);
+    assert_eq!(array.get(4), None);
+    assert_eq!(array.get(5), None);
+    assert_eq!(array.get(6), None);
+    assert_eq!(array.get(7), Some(90));
+    assert_eq!(array.get(8), None);
+    assert_eq!(array.get(9), None);
+}
+
+#[test]
+#[should_panic(expected = "Positions must be set in increasing order: got 2 after 2")]
+fn test_replacement_sparse() {
+    let mut builder = partial_value_array::new_sparse(5, 1);
+
+    builder.set(2, "first");
+    builder.set(2, "second");
+}
+
+#[test]
+#[should_panic(expected = "Positions must be set in increasing order: got 2 after 2")]
+fn test_replacement_dense() {
+    let mut builder = partial_value_array::new_dense(5);
+
+    builder.set(2, "first");
+    builder.set(2, "second");
+}
+
+#[test]
+#[should_panic(expected = "Position 5 is out of bounds for array of len 5")]
+fn test_array_bounds_check_sparse() {
+    let builder = partial_value_array::new_sparse::<usize>(5, 0);
+    let array = builder.build_bitfieldvec();
+    array.get(5);
+}
+
+#[test]
+#[should_panic(expected = "Position 5 is out of bounds for array of len 5")]
+fn test_array_bounds_check_dense() {
+    let builder = partial_value_array::new_dense::<usize>(5);
+    let array = builder.build_bitfieldvec();
+    array.get(5);
+}
+
+#[test]
+fn test_single_element() {
+    let mut builder = partial_value_array::new_sparse(1000, 1);
+    builder.set(500, 45678u32);
+
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 1000);
+    assert_eq!(array.num_values(), 1);
+    assert_eq!(array.get(500), Some(45678));
+
+    for i in 0..1000 {
+        if i != 500 {
+            assert_eq!(array.get(i), None);
+        }
+    }
+
+    let mut builder = partial_value_array::new_dense(1000);
+    builder.set(500, 45678u32);
+
+    let array = builder.build_bitfieldvec();
+
+    assert_eq!(array.len(), 1000);
+    assert_eq!(array.num_values(), 1);
+    assert_eq!(array.get(500), Some(45678));
+
+    for i in 0..1000 {
+        if i != 500 {
+            assert_eq!(array.get(i), None);
+        }
+    }
+}

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+use sux::array::SparseIndex;
 use sux::array::partial_value_array;
 
 #[test]
@@ -165,7 +166,7 @@ fn test_serialize() {
         use epserde::deser::Deserialize;
         <partial_value_array::PartialValueArray<
             u32,
-            partial_value_array::SparseIndex<Box<[usize]>>,
+            SparseIndex<Box<[usize]>>,
             BitFieldVec<u32>,
         >>::read_mem(&mut cursor, len)
         .expect("Could not deserialize")

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -91,19 +91,19 @@ fn test_replacement_dense() {
 }
 
 #[test]
-#[should_panic(expected = "Position 5 is out of bounds for array of len 5")]
+#[should_panic(expected = "Index out of bounds: 10 >= 10")]
 fn test_array_bounds_check_sparse() {
-    let builder = partial_value_array::new_sparse::<usize>(5, 0);
+    let builder = partial_value_array::new_sparse::<usize>(10, 0);
     let array = builder.build_bitfieldvec();
-    array.get(5);
+    array.get(10);
 }
 
 #[test]
-#[should_panic(expected = "Position 5 is out of bounds for array of len 5")]
+#[should_panic(expected = "Index out of bounds: 10 >= 10")]
 fn test_array_bounds_check_dense() {
-    let builder = partial_value_array::new_dense::<usize>(5);
+    let builder = partial_value_array::new_dense::<usize>(10);
     let array = builder.build_bitfieldvec();
-    array.get(5);
+    array.get(10);
 }
 
 #[test]

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -163,10 +163,12 @@ fn test_serialize() {
     cursor.set_position(0);
     let array2 = unsafe {
         use epserde::deser::Deserialize;
-        <partial_value_array::PartialValueArray<u32, partial_value_array::SparseIndex<Box<[usize]>>, BitFieldVec<u32>>>::read_mem(
-            &mut cursor,
-            len,
-        ).expect("Could not deserialize")
+        <partial_value_array::PartialValueArray<
+            u32,
+            partial_value_array::SparseIndex<Box<[usize]>>,
+            BitFieldVec<u32>,
+        >>::read_mem(&mut cursor, len)
+        .expect("Could not deserialize")
     };
     let array2 = array2.uncase();
 

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -144,7 +144,6 @@ fn test_serialize() {
     use epserde::utils::AlignedCursor;
     use maligned::A32;
     use sux::bits::BitFieldVec;
-    use sux::dict::elias_fano::EfDict;
 
     let mut builder = partial_value_array::new_sparse(10, 3);
 
@@ -157,18 +156,19 @@ fn test_serialize() {
     let mut cursor = <AlignedCursor<A32>>::new();
     unsafe {
         use epserde::ser::Serialize;
-        array.serialize(&mut cursor)?
+        array.serialize(&mut cursor).expect("Could not serialize")
     };
 
     let len = cursor.len();
     cursor.set_position(0);
     let array2 = unsafe {
         use epserde::deser::Deserialize;
-        <partial_value_array::PartialValueArray<u32, EfDict, BitFieldVec<usize>>>::read_mem(
+        <partial_value_array::PartialValueArray<u32, partial_value_array::SparseIndex<Box<[usize]>>, BitFieldVec<u32>>>::read_mem(
             &mut cursor,
             len,
-        )?
+        ).expect("Could not deserialize")
     };
+    let array2 = array2.uncase();
 
     assert_eq!(array.len(), array2.len());
     assert_eq!(array.num_values(), array2.num_values());

--- a/tests/test_partial_value_array.rs
+++ b/tests/test_partial_value_array.rs
@@ -174,7 +174,7 @@ fn test_serialize() {
 
     assert_eq!(array.len(), array2.len());
     assert_eq!(array.num_values(), array2.num_values());
-    for i in 0..20 {
+    for i in 0..10 {
         assert_eq!(array.get(i), array2.get(i), "Mismatch at index {i}");
     }
 }


### PR DESCRIPTION
This is an alternative to PartialArray for values that can fit in a BitFieldVec

Unfortunately, it does not seem to be possible to extend PartialArray to support this, as it would need two implementations of everything: one with `Box<[T]>` backend and one with `D: SliceByValue<Value=T> where T: Clone` backend, and these two would overlap (`Box<[T]>` implements `SliceByValue<Value=T>` when `T` implements `Clone`)