### PR TITLE
Switch to prefetch_index crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.27", features = ["derive"] }
 jiff = "0.2.15"
 fallible-iterator = "0.3.0"
+prefetch-index = "0.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }
@@ -66,7 +67,7 @@ zstd = ["dep:zstd"]
 cli = ["clap", "dep:epserde", "dep:deko"] # Build the binary utils (it's here so that cargo bench doesn't build them)
 fuzz = ["dep:arbitrary"]
 slow_tests = [] # Run slow tests (use --release)
-aarch64_prefetch = [] # Enable aarch64 prefetch (requires nightly)
+aarch64_prefetch = ["prefetch-index/aarch64"] # Enable aarch64 prefetch (requires nightly)
 mwhc = [] # Compile MWHC data structures (mainly for benchmarking)
 no_logging = [
 ] # Disable logging for binaries that build functions and filters (for benchmarking)

--- a/src/rank_sel/rank9.rs
+++ b/src/rank_sel/rank9.rs
@@ -275,9 +275,9 @@ impl<B: AsRef<[usize]> + BitLength, C: AsRef<[BlockCounters]>> RankUnchecked for
     fn prefetch(&self, pos: usize) {
         let word_pos = pos / usize::BITS as usize;
         let block = word_pos / Self::WORDS_PER_BLOCK;
-        crate::utils::prefetch_index(&self.bits, word_pos);
+        prefetch_index::prefetch_index(&self.bits, word_pos);
         // `counts` can be large enough to not fit in L3, so needs prefetching as well.
-        crate::utils::prefetch_index(&self.counts, block);
+        prefetch_index::prefetch_index(&self.counts, block);
     }
 }
 

--- a/src/rank_sel/rank_small.rs
+++ b/src/rank_sel/rank_small.rs
@@ -444,11 +444,11 @@ macro_rules! impl_rank_small {
             fn prefetch(&self, pos: usize) {
                 let word_pos = pos / 64 as usize;
                 let block = word_pos / Self::WORDS_PER_BLOCK;
-                crate::utils::prefetch_index(self.bits.as_ref(), word_pos);
+                prefetch_index::prefetch_index(self.bits.as_ref(), word_pos);
                 // `counts` can be large enough to not fit in L3, so needs prefetching as well.
-                crate::utils::prefetch_index(self.counts.as_ref(), block);
+                prefetch_index::prefetch_index(self.counts.as_ref(), block);
                 // `upper_counts` is small enough to fit in caches, so does not need prefetching.
-                // crate::utils::prefetch_index(self.upper_counts.as_ref(), word_pos / (1usize << 26));
+                // prefetch_index::prefetch_index(self.upper_counts.as_ref(), word_pos / (1usize << 26));
             }
         }
     };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,8 @@
 //! Utility traits and implementations.
 use common_traits::{Atomic, IntoAtomic};
 
+pub use prefetch_index::prefetch_index;
+
 pub mod lenders;
 pub use lenders::*;
 
@@ -180,35 +182,5 @@ impl SeedableRng for Mwc192 {
             y: u64::from_ne_bytes(s1),
             c: 1,
         }
-    }
-}
-
-/// Prefetches the cache line containing (the first byte of) `data[index]` into
-/// all levels of the cache.
-#[inline(always)]
-pub fn prefetch_index<T>(data: impl AsRef<[T]>, index: usize) {
-    let ptr = data.as_ref().as_ptr().wrapping_add(index) as *const i8;
-    #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-    unsafe {
-        std::arch::x86_64::_mm_prefetch(ptr, std::arch::x86_64::_MM_HINT_T0);
-    }
-    #[cfg(all(target_arch = "x86", target_feature = "sse"))]
-    unsafe {
-        std::arch::x86::_mm_prefetch(ptr, std::arch::x86::_MM_HINT_T0);
-    }
-    #[cfg(all(target_arch = "aarch64", feature = "aarch64_prefetch"))]
-    unsafe {
-        std::arch::aarch64::_prefetch::<
-            { std::arch::aarch64::_PREFETCH_READ },
-            { std::arch::aarch64::_PREFETCH_LOCALITY3 },
-        >(ptr);
-    }
-    #[cfg(not(any(
-        all(target_arch = "x86_64", target_feature = "sse"),
-        all(target_arch = "x86", target_feature = "sse"),
-        all(target_arch = "aarch64", feature = "aarch64_prefetch")
-    )))]
-    {
-        let _ = ptr; // Silence unused variable warning.
     }
 }


### PR DESCRIPTION
Ended up extracting it to a separate crate with proper CI tests for both x64 and aarch64.

Feel free to merge or not. Sorry again for the mess.

(The `pub use prefetch_index::prefetch_index` in `utils` could either stay or not. As you wish.)