### PR TITLE
Add `EliasFano::l` to expose the number of low bits

### DIFF
--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -325,7 +325,7 @@ impl<V, H, L> EliasFano<V, H, L> {
         )
     }
 
-    /// Estimate the size of an instance.
+    /// Estimate the size of an instance in bits.
     pub fn estimate_size(u: u64, n: usize) -> usize {
         2 * n + (n * (u as f64 / n as f64).log2().ceil() as usize)
     }

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -2273,7 +2273,7 @@ impl<V: Word + PrimitiveNumberAs<usize>> Extend<V> for EliasFanoBuilder<V> {
 /// A concurrent builder for [`EliasFano`].
 ///
 /// After creating an instance, you can use [`EliasFanoConcurrentBuilder::set`]
-/// to set the values concurrently. However, this operation is inherently
+/// to set the values concurrently, in any order. However, this operation is inherently
 /// unsafe as no check is performed on the provided data (e.g., duplicate
 /// indices and lack of monotonicity are not detected).
 ///
@@ -2344,6 +2344,8 @@ where
     }
 
     /// Sets a value concurrently.
+    ///
+    /// This allows setting values in _any_ order.
     ///
     /// # Safety
     /// - All indices must be distinct.

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -348,6 +348,12 @@ impl<V, H, L> EliasFano<V, H, L> {
         self.u
     }
 
+    /// Returns the number of explicitly stored lower bits for each value.
+    #[inline]
+    pub fn num_lower_bits(&self) -> usize {
+        self.l
+    }
+
     /// Replaces the high bits.
     ///
     /// # Safety


### PR DESCRIPTION
See #106.

Could be called `low_bits` instead, but that could be confused with the actual data itself.