### PR TITLE
Security/correctness hardening and 0.16.0 release prep

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]
-
 [target.wasm32-wasip1]
 runner = "wasmtime"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,35 @@
 - Several CLI utilities validate their arguments instead of dividing by zero
   or looping forever.
 
+- Select structure builders (`Select9`, `SelectAdapt`, `SelectAdaptConst`,
+  `SelectSmall`) now ignore stale backing words beyond the logical length
+  (reachable via `BitVec::pop`/`resize`), instead of panicking or indexing
+  padding positions.
+
+- `Modulo2System::gaussian_elimination` no longer rejects solvable systems
+  containing redundant identity rows.
+
+- The branchy Huffman decoder returns `None` for out-of-window values
+  instead of panicking, matching the branchless strategy.
+
+- The parallel builder no longer applies the max-shard sanity check to
+  hinted builds, mirroring the sequential builder.
+
+- `VBuilder::eps` is now validated to lie in the open interval (0, 1).
+
+- New `ShardEdge::validate` used by `VFunc`/`VFunc2`/`VFilter` validation,
+  and new `CompVFunc::validate`, so corrupt deserialized shard parameters
+  are reported as errors instead of panicking.
+
+- `BitVec::reserve`, `reserve_exact`, and `append_value` use checked
+  bit-length arithmetic.
+
+- Oversized byte-key LCP lengths (> `u32::MAX` bits) are reported as errors
+  by the `Lcp2Mmphf` constructors instead of panicking.
+
+- The CLI utilities propagate unaligned-conversion errors instead of
+  panicking on `--unaligned`.
+
 ### Improved
 
 - Structured logging for structures with substructures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,24 @@
 - **Breaking:** `UnalignedConversionError` is now a structured
   (`non_exhaustive`) enum instead of a wrapper around a `String`.
 
+- **Breaking:** `FairChunks::new_with` is now `unsafe`; the caller must uphold
+  its documented contract (a nondecreasing cumulative weight function,
+  `max_weight` equal to its last element, and `num_weights` one less than the
+  length of the function), which the constructor does not check.
+
+- **Breaking:** boxed `VFilter` backends wider than 64 bits are now rejected,
+  and the requested filter bit width is capped at `min(64, W::BITS)` and must
+  be positive. The verification hash is a 64-bit remixed hash, so wider words
+  previously stored fictional high-bit entropy; out-of-range widths now return
+  an error instead of building a filter with an unachievable false-positive
+  rate.
+
+- **Breaking:** the fallible constructors of `SignedFunc`, `LcpMmphf`, and
+  `Lcp2Mmphf` return `Err` instead of panicking on invalid input: `SignedFunc`
+  rejects a non-positive hash width, and the `LcpMmphf`/`Lcp2Mmphf` builders
+  report a key-count mismatch (the key iterator yielding a number of keys
+  different from the declared count).
+
 ## [0.14.0] - 2026-04-11
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## unreleased
+## [0.16.0] - 2026-07-08
 
 ### New
 
@@ -41,6 +41,10 @@
 - New `BitFieldVec::wrap` method to create a bit-field vector with a
   given backend.
 
+- New `validate` method on `BitFieldVec`, `VFunc`, `VFunc2`, and `VFilter`
+  that checks the structure's invariants after deserializing from an
+  untrusted source, so that the safe getters cannot read out of bounds.
+
 ### Fixed
 
 - Unsound reference-based `From` implementations between `BitVec`,
@@ -71,6 +75,26 @@
 
 - Fixed subtraction overflow when appending to a vector with excess capacity.
 
+- Safe query and access paths now use checked arithmetic and mask dirty
+  padding bits, preventing overflow panics and spurious rank/select results
+  on structures built from unsanitized input.
+
+- A `BitFieldVec` of bit width zero always keeps a backing word, so
+  zero-width vectors no longer read out of bounds.
+
+- `Lcp2Mmphf` queries on absent keys no longer index the remap table out of
+  bounds, and LCP bit-lengths are stored as `u32` on all targets (they
+  previously wrapped above 65535 bits on 32-bit platforms).
+
+- `VFunc2` handles wide (`u128`) values and 32-bit `usize` losslessly:
+  distinct values sharing their low bits no longer collide.
+
+- The parallel `VBuilder` rejects `offline` mode instead of silently
+  ignoring it, bounds `MaxShardTooBig` retries, and validates `eps`.
+
+- Several CLI utilities validate their arguments instead of dividing by zero
+  or looping forever.
+
 ### Improved
 
 - Structured logging for structures with substructures.
@@ -89,6 +113,14 @@
 - Thanks to the new ε-serde, `VFilter` does not have `F` anymore
   as parameter. Moreover, other structures such as `VFunc2` will
   actually map into memory their bulk data.
+
+- **Breaking:** the two-argument bit-range methods of `BitVecValueOps`,
+  `get_value`/`get_value_unchecked`, are renamed to
+  `get_bits`/`get_bits_unchecked` to avoid clashing with the index-based
+  `SliceByValue` methods of the same names.
+
+- **Breaking:** `UnalignedConversionError` is now a structured
+  (`non_exhaustive`) enum instead of a wrapper around a `String`.
 
 ## [0.14.0] - 2026-04-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ log = "0.4.20"
 dsi-progress-logger = "0.8.7"
 tempfile = "3.9.0"
 lender = "0.6.0"
-# TODO: drop `path` once epserde 0.13.0 is published to crates.io.
-epserde = { version = "0.13", path = "../epserde-rs/epserde", optional = true, default-features = false, features = ["std", "derive"] }
+#epserde = { version = "0.12.5", optional = true, default-features = false, features = ["std", "derive"] }
+epserde = { path = "../epserde-rs/epserde", optional = true, default-features = false, features = ["std", "derive"] }
 zstd = { version = "0.13.1", optional = true }
 flate2 = { version = "1.0.28", optional = true }
 rand = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ mmap = ["epserde/mmap"]
 [profile.release]
 opt-level = 3 # like --release
 #lto = "fat"              # Full LTO
-debug = true             # Include debug info.
 overflow-checks = false  # Disable integer overflow checks.
 debug-assertions = false # Disable debug assertions.
 #codegen-units = 1        # slower compile times, but maybe better perf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ required-features = ["cli", "epserde", "deko", "rayon"]
 
 [[bin]]
 name = "mem_usage"
-required-features = ["cli"]
+required-features = ["clap"]
 
 [[example]]
 name = "bench_rear_coded_list"
@@ -149,7 +149,7 @@ required-features = ["cli", "epserde", "deko", "rayon"]
 
 [[example]]
 name = "bench_lcp_mmphf"
-required-features = ["epserde", "deko"]
+required-features = ["cli", "epserde", "deko"]
 
 [[example]]
 name = "bench_phast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,34 @@ required-features = ["rayon"]
 name = "example_vfilter"
 required-features = ["rayon"]
 
+[[example]]
+name = "bench_shard_exp"
+required-features = ["rayon"]
+
+[[example]]
+name = "bench_solve_system"
+required-features = ["rayon"]
+
+[[example]]
+name = "corr_peel_sweep"
+required-features = ["rayon"]
+
+[[example]]
+name = "find_min_c"
+required-features = ["rayon"]
+
+[[example]]
+name = "prof_comp_vfunc"
+required-features = ["rayon"]
+
+[[example]]
+name = "profile_comp_vfunc"
+required-features = ["rayon"]
+
+[[example]]
+name = "sweep_c"
+required-features = ["rayon"]
+
 [[bench]]
 name = "rank_sel"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
 	"Sebastiano Vigna <sebastiano.vigna@unimi.it>",
 ]
 description = "A pure Rust implementation of succinct and compressed data structures"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 repository = "https://github.com/vigna/sux-rs"
 license = "Apache-2.0 OR LGPL-2.1-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,11 +158,11 @@ required-features = ["cli"]
 
 [[example]]
 name = "comp_vfunc_stress"
-required-features = ["cli"]
+required-features = ["cli", "rayon"]
 
 [[example]]
 name = "bench_comp_vfunc_data"
-required-features = ["cli"]
+required-features = ["cli", "rayon"]
  
 [[example]]
 name = "example_vfunc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ log = "0.4.20"
 dsi-progress-logger = "0.8.7"
 tempfile = "3.9.0"
 lender = "0.6.0"
-epserde = { version = "0.13", optional = true, default-features = false, features = ["std", "derive"] }
+# TODO: drop `path` once epserde 0.13.0 is published to crates.io.
+epserde = { version = "0.13", path = "../epserde-rs/epserde", optional = true, default-features = false, features = ["std", "derive"] }
 zstd = { version = "0.13.1", optional = true }
 flate2 = { version = "1.0.28", optional = true }
 rand = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ log = "0.4.20"
 dsi-progress-logger = "0.8.7"
 tempfile = "3.9.0"
 lender = "0.6.0"
-#epserde = { version = "0.12.5", optional = true, default-features = false, features = ["std", "derive"] }
-epserde = { path = "../epserde-rs/epserde", optional = true, default-features = false, features = ["std", "derive"] }
+epserde = { version = "0.13", optional = true, default-features = false, features = ["std", "derive"] }
 zstd = { version = "0.13.1", optional = true }
 flate2 = { version = "1.0.28", optional = true }
 rand = "0.10.0"

--- a/src/array/partial_array.rs
+++ b/src/array/partial_array.rs
@@ -19,10 +19,10 @@ use crate::dict::elias_fano::EliasFano;
 use crate::panic_if_out_of_bounds;
 use crate::rank_sel::{Rank9, SelectZeroAdaptConst};
 use crate::traits::Backend;
+use crate::traits::BitCount;
 use crate::traits::TryIntoUnaligned;
 use crate::traits::Unaligned;
 use crate::traits::{BitVecOps, BitVecOpsMut};
-use crate::traits::BitCount;
 use crate::traits::{RankUnchecked, SuccUnchecked};
 
 // Rank9 is inherently u64-based, so the dense index must use u64 backing

--- a/src/array/partial_array.rs
+++ b/src/array/partial_array.rs
@@ -195,8 +195,10 @@ impl<T> PartialArrayBuilder<T, EliasFanoBuilder<u64>> {
             );
         }
         panic_if_out_of_bounds!(position, self.len);
-        // SAFETY: conditions have been just checked
-        unsafe { self.builder.push_unchecked(position as u64) };
+        // usize fits u64 on all supported targets, so this cast is lossless. The
+        // checked push panics "Too many values" past the declared capacity,
+        // upholding EliasFano's unchecked "at most n pushes" precondition.
+        self.builder.push(position as u64);
         self.values.push(value);
         self.min_next_pos = position + 1;
     }

--- a/src/array/partial_array.rs
+++ b/src/array/partial_array.rs
@@ -22,6 +22,7 @@ use crate::traits::Backend;
 use crate::traits::TryIntoUnaligned;
 use crate::traits::Unaligned;
 use crate::traits::{BitVecOps, BitVecOpsMut};
+use crate::traits::BitCount;
 use crate::traits::{RankUnchecked, SuccUnchecked};
 
 // Rank9 is inherently u64-based, so the dense index must use u64 backing
@@ -335,6 +336,25 @@ impl<T, V: AsRef<[T]>> PartialArray<T, DenseIndex, V> {
         // SAFETY: necessarily value_index < num_values().
         Some(unsafe { self.values.as_ref().get_unchecked(value_index) })
     }
+
+    /// Checks that the rank index is consistent with the stored values.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: safe accessors otherwise trust the index and
+    /// reach unchecked reads of the value array on malformed input.
+    ///
+    /// The check verifies every rank counter against the marker bits
+    /// (`O(len)`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        self.index.validate()?;
+        anyhow::ensure!(
+            self.index.count_ones() == self.values.as_ref().len(),
+            "the index marks {} positions but {} values are stored",
+            self.index.count_ones(),
+            self.values.as_ref().len()
+        );
+        Ok(())
+    }
 }
 
 impl<
@@ -403,6 +423,52 @@ where
             Some(unsafe { self.values.as_ref().get_unchecked(index) })
         }
     }
+
+    /// Checks that the position index is consistent with the stored values.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: safe accessors otherwise trust the index and
+    /// reach unchecked reads of the value array on malformed input.
+    ///
+    /// The check validates the underlying [Elias–Fano] representation and
+    /// rescans the stored positions (`O(num_values)`). The inventories of the
+    /// selection wrapper are not validated: for fully untrusted data, rebuild
+    /// the index.
+    ///
+    /// [Elias–Fano]: crate::dict::EliasFano
+    pub fn validate(&self) -> anyhow::Result<()>
+    where
+        L: crate::traits::bit_field_slice::BitWidth,
+        SelectZeroAdaptConst<BitVec<D>, I>: AsRef<[usize]> + crate::traits::BitLength,
+    {
+        self.index.ef.validate()?;
+        anyhow::ensure!(
+            self.index.ef.len() == self.values.as_ref().len(),
+            "the index stores {} positions but {} values are stored",
+            self.index.ef.len(),
+            self.values.as_ref().len()
+        );
+        // The upper bound of the Elias–Fano structure is the array length,
+        // used as a sentinel: stored positions must be strictly smaller.
+        let len = self.index.ef.upper_bound();
+        let mut last = None;
+        for pos in self.index.ef.iter() {
+            anyhow::ensure!(
+                pos < len,
+                "stored position {pos} is not smaller than the array length {len}"
+            );
+            last = Some(pos);
+        }
+        // Lossless: usize fits u64 on all supported targets.
+        let first_invalid = self.index.first_invalid_pos as u64;
+        // Positions are < len <= u64::MAX, so the increment cannot overflow.
+        let expected = last.map_or(0, |p| p + 1);
+        anyhow::ensure!(
+            first_invalid == expected,
+            "the first invalid position is {first_invalid} instead of {expected}"
+        );
+        Ok(())
+    }
 }
 
 /// Returns an option even when using `get_value_unchecked` because it should be safe to call
@@ -468,5 +534,47 @@ impl<T, P: TryIntoUnaligned, V> TryIntoUnaligned for PartialArray<T, P, V> {
             values: self.values,
             _marker: PhantomData,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_rejects_corrupt_dense() {
+        let mut builder = new_dense(100);
+        builder.set(1, 10u8);
+        builder.set(50, 20);
+        let mut dense = builder.build();
+        // Fewer values than marked positions.
+        dense.values = vec![10u8].into_boxed_slice();
+        assert!(dense.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_corrupt_sparse() {
+        let mut builder = new_sparse(100, 2);
+        builder.set(1, 10u8);
+        builder.set(50, 20);
+        let mut sparse = builder.build();
+        // Wrong first invalid position.
+        sparse.index.first_invalid_pos = 60;
+        assert!(sparse.validate().is_err());
+
+        // A stored position equal to the array length: the Elias-Fano upper
+        // bound is a sentinel, so this passes plain EF validation but is
+        // inconsistent with the array semantics.
+        let mut efb = EliasFanoBuilder::<u64>::new(1, 100);
+        efb.push(100);
+        let sparse = PartialArray {
+            index: SparseIndex {
+                ef: efb.build_with_dict(),
+                first_invalid_pos: 101,
+            },
+            values: vec![10u8].into_boxed_slice(),
+            _marker: PhantomData,
+        };
+        assert!(sparse.validate().is_err());
     }
 }

--- a/src/bal_paren/jacobson.rs
+++ b/src/bal_paren/jacobson.rs
@@ -353,10 +353,16 @@ fn check_balance(words: &[usize], len: usize) -> anyhow::Result<()> {
             depth += 1;
         } else {
             depth -= 1;
-            anyhow::ensure!(depth >= 0, "unbalanced parentheses: negative depth at position {i}");
+            anyhow::ensure!(
+                depth >= 0,
+                "unbalanced parentheses: negative depth at position {i}"
+            );
         }
     }
-    anyhow::ensure!(depth == 0, "unbalanced parentheses: final depth is {depth} instead of 0");
+    anyhow::ensure!(
+        depth == 0,
+        "unbalanced parentheses: final depth is {depth} instead of 0"
+    );
     Ok(())
 }
 

--- a/src/bal_paren/jacobson.rs
+++ b/src/bal_paren/jacobson.rs
@@ -338,6 +338,28 @@ pub struct JacobsonBalParen<B = BitVec<Box<[usize]>>, P = EfDict<usize>, O = Com
     pioneer_match_offsets: O,
 }
 
+/// Checks that `words` encodes a balanced parenthesis sequence over its first
+/// `len` bits: 1-bits open, 0-bits close, the running depth never goes
+/// negative, and it returns to zero at the end.
+fn check_balance(words: &[usize], len: usize) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        words.len() >= len.div_ceil(WORD_BITS),
+        "the backend has {} words, too few for {len} bits",
+        words.len()
+    );
+    let mut depth: i64 = 0;
+    for i in 0..len {
+        if words[i / WORD_BITS] & (1usize << (i % WORD_BITS)) != 0 {
+            depth += 1;
+        } else {
+            depth -= 1;
+            anyhow::ensure!(depth >= 0, "unbalanced parentheses: negative depth at position {i}");
+        }
+    }
+    anyhow::ensure!(depth == 0, "unbalanced parentheses: final depth is {depth} instead of 0");
+    Ok(())
+}
+
 /// Identifies pioneers and builds the Elias–Fano position index.
 ///
 /// Returns `(ef_positions, pioneer_match_offsets)` where the offsets are
@@ -348,19 +370,8 @@ fn build_pioneers(words: impl AsRef<[usize]> + BitLength) -> (EfDict<usize>, Vec
     let num_words = len.div_ceil(WORD_BITS);
     debug_assert!(words.len() >= num_words);
 
-    // The constructors document a panic on unbalanced input. Validate up front:
-    // 1-bits open, 0-bits close; the depth must never go negative and must
-    // return to zero over the logical length.
-    let mut depth: i64 = 0;
-    for i in 0..len {
-        if words[i / WORD_BITS] & (1usize << (i % WORD_BITS)) != 0 {
-            depth += 1;
-        } else {
-            depth -= 1;
-            assert!(depth >= 0, "Unbalanced parentheses");
-        }
-    }
-    assert!(depth == 0, "Unbalanced parentheses");
+    // The constructors document a panic on unbalanced input.
+    check_balance(words, len).expect("Unbalanced parentheses");
 
     let mut count = vec![0i32; num_words];
     let mut residual = vec![0usize; num_words];
@@ -479,6 +490,50 @@ impl<B: AsRef<[usize]> + BitLength> JacobsonBalParen<B> {
             pioneer_positions: ef_positions,
             pioneer_match_offsets: offsets,
         }
+    }
+}
+
+impl<B: AsRef<[usize]> + BitLength, O: SliceByValue<Value = usize>>
+    JacobsonBalParen<B, EfDict<usize>, O>
+{
+    /// Checks that the pioneer index and match offsets are consistent with
+    /// the parenthesis bit vector.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: [`find_close`](BalParen::find_close) otherwise
+    /// trusts the pioneer positions and offsets and indexes the backing words
+    /// with `pioneer + offset`, which can read out of bounds on malformed
+    /// input.
+    ///
+    /// The check rebuilds the canonical pioneers from the bit vector and
+    /// compares them against the stored index (`O(len)`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        check_balance(self.paren.as_ref(), self.paren.len())?;
+        let (positions, matches) = build_pioneers(&self.paren);
+        anyhow::ensure!(
+            self.pioneer_match_offsets.len() == matches.len(),
+            "the offset structure has {} entries instead of {}",
+            self.pioneer_match_offsets.len(),
+            matches.len()
+        );
+        let mut stored = self.pioneer_positions.iter();
+        for (i, canonical) in positions.iter().enumerate() {
+            anyhow::ensure!(
+                stored.next() == Some(canonical),
+                "pioneer position {i} does not match the canonical position {canonical}"
+            );
+            let offset = self.pioneer_match_offsets.index_value(i);
+            anyhow::ensure!(
+                offset == matches[i],
+                "pioneer offset {i} is {offset} instead of {}",
+                matches[i]
+            );
+        }
+        anyhow::ensure!(
+            stored.next().is_none(),
+            "the pioneer index has more positions than the canonical rebuild"
+        );
+        Ok(())
     }
 }
 
@@ -1024,5 +1079,32 @@ mod tests {
         // "()" pairs: no far parens
         assert_eq!(count_far_open(usize::MAX / 3, WORD_BITS), 0);
         assert_eq!(count_far_close(usize::MAX / 3, WORD_BITS), 0);
+    }
+
+    #[test]
+    fn test_validate() {
+        let bp = JacobsonBalParen::new(random_balanced(256));
+        assert!(bp.validate().is_ok());
+
+        // Unbalanced parentheses: flip the first (open) bit to a close, so
+        // the running depth goes negative at position 0.
+        let mut bits = random_balanced(256);
+        bits.set(0, false);
+        let bad = JacobsonBalParen {
+            paren: bits,
+            pioneer_positions: bp.pioneer_positions.clone(),
+            pioneer_match_offsets: bp.pioneer_match_offsets.clone(),
+        };
+        assert!(bad.validate().is_err());
+
+        // Corrupt offsets: balanced parentheses but zeroed match offsets.
+        let count = bp.pioneer_match_offsets.len();
+        assert!(count > 0, "expected far matches at length 256");
+        let bad = JacobsonBalParen {
+            paren: random_balanced(256),
+            pioneer_positions: bp.pioneer_positions.clone(),
+            pioneer_match_offsets: CompIntList::new(0usize, &vec![0usize; count]),
+        };
+        assert!(bad.validate().is_err());
     }
 }

--- a/src/bal_paren/jacobson.rs
+++ b/src/bal_paren/jacobson.rs
@@ -348,6 +348,20 @@ fn build_pioneers(words: impl AsRef<[usize]> + BitLength) -> (EfDict<usize>, Vec
     let num_words = len.div_ceil(WORD_BITS);
     debug_assert!(words.len() >= num_words);
 
+    // The constructors document a panic on unbalanced input. Validate up front:
+    // 1-bits open, 0-bits close; the depth must never go negative and must
+    // return to zero over the logical length.
+    let mut depth: i64 = 0;
+    for i in 0..len {
+        if words[i / WORD_BITS] & (1usize << (i % WORD_BITS)) != 0 {
+            depth += 1;
+        } else {
+            depth -= 1;
+            assert!(depth >= 0, "Unbalanced parentheses");
+        }
+    }
+    assert!(depth == 0, "Unbalanced parentheses");
+
     let mut count = vec![0i32; num_words];
     let mut residual = vec![0usize; num_words];
 
@@ -612,7 +626,7 @@ impl<
 
         // Try to find the close within the same word
         let result = find_near_close(words[word_idx] >> bit_idx);
-        if result < WORD_BITS - bit_idx {
+        if result < (WORD_BITS - bit_idx).min(self.paren.len() - pos) {
             return Some(word_idx * WORD_BITS + bit_idx + result);
         }
 

--- a/src/bin/comp_vfunc.rs
+++ b/src/bin/comp_vfunc.rs
@@ -16,6 +16,7 @@ use rand::{RngExt, SeedableRng};
 use rdst::RadixKey;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::num::NonZeroUsize;
 use sux::bits::BitVec;
 use sux::cli::{BuilderArgs, read_concat_lines, str_slice_from_offsets};
 use sux::func::codec::HuffmanConf;
@@ -65,10 +66,10 @@ struct Args {
     /// Generate values with a Zipf distribution (exponent 1) over
     /// [0 . . K).​
     #[arg(long)]
-    zipf: Option<usize>,
+    zipf: Option<NonZeroUsize>,
     /// Generate values uniformly distributed in [0 . . K).​
     #[arg(long)]
-    uniform: Option<usize>,
+    uniform: Option<NonZeroUsize>,
     /// Save the structure in unaligned form (faster, if available).​
     #[arg(long, short)]
     unaligned: bool,
@@ -171,11 +172,11 @@ fn generate_synthetic_values(args: &Args, n: usize) -> Result<Vec<usize>> {
             .map(|_| rng.random::<u64>().trailing_zeros() as usize)
             .collect())
     } else if let Some(k) = args.zipf {
-        let cdf = zipf_cdf(1.0, k);
+        let cdf = zipf_cdf(1.0, k.get());
         Ok((0..n).map(|_| sample_zipf(&cdf, &mut rng)).collect())
     } else if let Some(k) = args.uniform {
         Ok((0..n)
-            .map(|_| (rng.random::<u64>() % k as u64) as usize)
+            .map(|_| (rng.random::<u64>() % k.get() as u64) as usize)
             .collect())
     } else {
         bail!("one of --values, --geometric, --zipf, or --uniform is required");

--- a/src/bin/comp_vfunc.rs
+++ b/src/bin/comp_vfunc.rs
@@ -221,6 +221,12 @@ where
             generate_synthetic_values(&args, n)?
         };
         let n = values.len();
+        if args.values.is_some() {
+            // With an explicit values file the key count must match exactly;
+            // otherwise keys past values.len() would be silently ignored.
+            let key_count = count_keys(filename)?;
+            ensure!(key_count == n, "key count {key_count} != value count {n}");
+        }
         if args.sequential {
             let keys = DekoBufLineLender::from_path(filename)?.take(n);
             let func = <CompVFunc<str, BitVec<Box<[usize]>>, S, E>>::try_new_with_builder(

--- a/src/bin/comp_vfunc.rs
+++ b/src/bin/comp_vfunc.rs
@@ -126,7 +126,7 @@ macro_rules! maybe_store {
     ($func:expr, $out:expr, $unaligned:expr) => {
         if let Some(out) = $out {
             if $unaligned {
-                unsafe { $func.try_into_unaligned().unwrap().store(&out)? };
+                unsafe { $func.try_into_unaligned()?.store(&out)? };
             } else {
                 unsafe { $func.store(&out)? };
             }

--- a/src/bin/lcp_mmphf.rs
+++ b/src/bin/lcp_mmphf.rs
@@ -113,7 +113,7 @@ macro_rules! maybe_store {
     ($func:expr, $out:expr, $unaligned:expr) => {
         if let Some(ref f) = $out {
             if $unaligned {
-                unsafe { $func.try_into_unaligned().unwrap().store(f) }?;
+                unsafe { $func.try_into_unaligned()?.store(f) }?;
             } else {
                 unsafe { $func.store(f) }?;
             }

--- a/src/bin/mem_usage.rs
+++ b/src/bin/mem_usage.rs
@@ -97,6 +97,8 @@ fn mem_usage<S: Struct + MemSize + MemDbg + BitLength>(
     name: &str,
 ) {
     let mut rng = SmallRng::seed_from_u64(0);
+    assert!(len >= 2, "len must be at least 2");
+    assert!(density > 0.0 && density <= 1.0, "density must be in (0, 1]");
     let (density0, density1) = if uniform {
         (density, density)
     } else {

--- a/src/bin/mrcl.rs
+++ b/src/bin/mrcl.rs
@@ -39,6 +39,7 @@ fn main() -> Result<()> {
     if args.unsorted {
         unsafe {
             let rcl = <RearCodedListStr<false>>::load_full(&args.rcl)?;
+            rcl.validate()?;
             let width = rcl.len().bit_len() as usize;
 
             let mut map = bit_field_vec![width => 0; rcl.len()];
@@ -55,11 +56,14 @@ fn main() -> Result<()> {
                 map = inv_map;
             }
 
-            <MappedRearCodedListStr<false>>::from_parts(rcl, map.into()).store(&args.dest)?;
+            let mrcl = <MappedRearCodedListStr<false>>::from_parts(rcl, map.into());
+            mrcl.validate()?;
+            mrcl.store(&args.dest)?;
         }
     } else {
         unsafe {
             let rcl = <RearCodedListStr<true>>::load_full(&args.rcl)?;
+            rcl.validate()?;
             let width = rcl.len().bit_len() as usize;
 
             let mut map = bit_field_vec![width => 0; rcl.len()];
@@ -76,7 +80,9 @@ fn main() -> Result<()> {
                 map = inv_map;
             }
 
-            <MappedRearCodedListStr<true>>::from_parts(rcl, map.into()).store(&args.dest)?;
+            let mrcl = <MappedRearCodedListStr<true>>::from_parts(rcl, map.into());
+            mrcl.validate()?;
+            mrcl.store(&args.dest)?;
         }
     }
 

--- a/src/bin/vfilter.rs
+++ b/src/bin/vfilter.rs
@@ -226,7 +226,7 @@ where
             )?;
             if let Some(filename) = args.filter {
                 if args.unaligned {
-                    unsafe { filter.try_into_unaligned().unwrap().store(filename)? };
+                    unsafe { filter.try_into_unaligned()?.store(filename)? };
                 } else {
                     unsafe { filter.store(filename)? };
                 }
@@ -247,7 +247,7 @@ where
             )?;
             if let Some(filename) = args.filter {
                 if args.unaligned {
-                    unsafe { filter.try_into_unaligned().unwrap().store(filename)? };
+                    unsafe { filter.try_into_unaligned()?.store(filename)? };
                 } else {
                     unsafe { filter.store(filename)? };
                 }
@@ -268,7 +268,7 @@ where
             )?;
             if let Some(filename) = args.filter {
                 if args.unaligned {
-                    unsafe { filter.try_into_unaligned().unwrap().store(filename)? };
+                    unsafe { filter.try_into_unaligned()?.store(filename)? };
                 } else {
                     unsafe { filter.store(filename)? };
                 }
@@ -280,7 +280,7 @@ where
             )?;
             if let Some(filename) = args.filter {
                 if args.unaligned {
-                    unsafe { filter.try_into_unaligned().unwrap().store(filename)? };
+                    unsafe { filter.try_into_unaligned()?.store(filename)? };
                 } else {
                     unsafe { filter.store(filename)? };
                 }

--- a/src/bin/vfunc.rs
+++ b/src/bin/vfunc.rs
@@ -89,7 +89,7 @@ macro_rules! filename_save_sign_seq(
             )?;
         if let Some(filename) = $func {
             if $unaligned {
-                unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                unsafe { func.try_into_unaligned()?.store(filename) }?;
             } else {
                 unsafe { func.store(filename) }?;
             }
@@ -107,7 +107,7 @@ macro_rules! n_save_sign_seq(
             )?;
         if let Some(filename) = $func {
             if $unaligned {
-                unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                unsafe { func.try_into_unaligned()?.store(filename) }?;
             } else {
                 unsafe { func.store(filename) }?;
             }
@@ -125,7 +125,7 @@ macro_rules! n_save_sign_par(
             )?;
         if let Some(filename) = $func {
             if $unaligned {
-                unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                unsafe { func.try_into_unaligned()?.store(filename) }?;
             } else {
                 unsafe { func.store(filename) }?;
             }
@@ -145,7 +145,7 @@ macro_rules! filename_save_sign_par(
             )?;
         if let Some(filename) = $func {
             if $unaligned {
-                unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                unsafe { func.try_into_unaligned()?.store(filename) }?;
             } else {
                 unsafe { func.store(filename) }?;
             }
@@ -207,7 +207,7 @@ where
                     )?;
                     if let Some(filename) = args.func {
                         if args.unaligned {
-                            unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                            unsafe { func.try_into_unaligned()?.store(filename) }?;
                         } else {
                             unsafe { func.store(filename) }?;
                         }
@@ -273,7 +273,7 @@ where
                         )?;
                     if let Some(filename) = args.func {
                         if args.unaligned {
-                            unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                            unsafe { func.try_into_unaligned()?.store(filename) }?;
                         } else {
                             unsafe { func.store(filename) }?;
                         }
@@ -311,7 +311,7 @@ where
                         )?;
                     if let Some(filename) = args.func {
                         if args.unaligned {
-                            unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                            unsafe { func.try_into_unaligned()?.store(filename) }?;
                         } else {
                             unsafe { func.store(filename) }?;
                         }
@@ -341,7 +341,7 @@ where
                         )?;
                     if let Some(filename) = args.func {
                         if args.unaligned {
-                            unsafe { func.try_into_unaligned().unwrap().store(filename) }?;
+                            unsafe { func.try_into_unaligned()?.store(filename) }?;
                         } else {
                             unsafe { func.store(filename) }?;
                         }

--- a/src/bin/vfunc2.rs
+++ b/src/bin/vfunc2.rs
@@ -111,7 +111,7 @@ macro_rules! maybe_store {
     ($func:expr, $out:expr, $unaligned:expr) => {
         if let Some(out) = $out {
             if $unaligned {
-                unsafe { $func.try_into_unaligned().unwrap().store(&out)? };
+                unsafe { $func.try_into_unaligned()?.store(&out)? };
             } else {
                 unsafe { $func.store(&out)? };
             }

--- a/src/bin/vfunc2.rs
+++ b/src/bin/vfunc2.rs
@@ -16,6 +16,7 @@ use rand::{RngExt, SeedableRng};
 use rdst::RadixKey;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::num::NonZeroUsize;
 use std::ops::{BitXor, BitXorAssign};
 use sux::bits::BitFieldVec;
 use sux::cli::{BuilderArgs, ShardingArgs, read_concat_lines, str_slice_from_offsets};
@@ -65,10 +66,10 @@ struct Args {
     /// Generate values with a Zipf distribution (exponent 1) over
     /// [0 . . K).​
     #[arg(long)]
-    zipf: Option<usize>,
+    zipf: Option<NonZeroUsize>,
     /// Generate values uniformly distributed in [0 . . K).​
     #[arg(long)]
-    uniform: Option<usize>,
+    uniform: Option<NonZeroUsize>,
     /// Save the structure in unaligned form (faster, if available).​
     #[arg(long, short)]
     unaligned: bool,
@@ -159,11 +160,11 @@ fn generate_synthetic_values(args: &Args, n: usize) -> Result<Vec<usize>> {
             .map(|_| rng.random::<u64>().trailing_zeros() as usize)
             .collect())
     } else if let Some(k) = args.zipf {
-        let cdf = zipf_cdf(1.0, k);
+        let cdf = zipf_cdf(1.0, k.get());
         Ok((0..n).map(|_| sample_zipf(&cdf, &mut rng)).collect())
     } else if let Some(k) = args.uniform {
         Ok((0..n)
-            .map(|_| (rng.random::<u64>() % k as u64) as usize)
+            .map(|_| (rng.random::<u64>() % k.get() as u64) as usize)
             .collect())
     } else {
         bail!("one of --values, --geometric, --zipf, or --uniform is required");

--- a/src/bin/vfunc2.rs
+++ b/src/bin/vfunc2.rs
@@ -206,6 +206,12 @@ where
             generate_synthetic_values(&args, n)?
         };
         let n = values.len();
+        if args.values.is_some() {
+            // With an explicit values file the key count must match exactly;
+            // otherwise keys past values.len() would be silently ignored.
+            let key_count = count_keys(filename)?;
+            ensure!(key_count == n, "key count {key_count} != value count {n}");
+        }
         let mut builder = args
             .builder
             .configure(VBuilder::<BitFieldVec<Box<[usize]>>, S, E>::default());

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -1413,7 +1413,8 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> crate::traits::UncheckedIterator
             self.window = B::Word::ZERO;
             self.fill = 0;
         } else {
-            res = ((res << used) | (self.window >> (B::Word::BITS as usize - used))) & self.vec.mask; // not in a loop
+            res =
+                ((res << used) | (self.window >> (B::Word::BITS as usize - used))) & self.vec.mask; // not in a loop
             self.window <<= used;
             self.fill = B::Word::BITS as usize - used;
         }
@@ -1577,7 +1578,8 @@ impl<W: Word> core::iter::Extend<W> for BitFieldVec<Vec<W>> {
                 .and_then(|total| total.checked_mul(self.bit_width))
                 .map(|bits| bits.div_ceil(W::BITS as usize))
             {
-                self.bits.reserve(needed_words.saturating_sub(self.bits.len()));
+                self.bits
+                    .reserve(needed_words.saturating_sub(self.bits.len()));
             }
         }
         for value in iter {

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -340,6 +340,49 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitFieldVec<B> {
         (&self.bits.as_ref()[word_index]) as *const _
     }
 
+    /// Checks the internal invariants relied upon by the unchecked accessors.
+    ///
+    /// Intended to be called after deserializing a [`BitFieldVec`] from an
+    /// untrusted source: it verifies that `bit_width` fits the word width, that
+    /// the cached `mask` matches `bit_width`, and that the backing storage is
+    /// large enough to hold `len` values. Once it returns `Ok`, the unchecked
+    /// accessors (and hence the safe getters) cannot read out of bounds.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let w = B::Word::BITS as usize; // BITS <= 128, lossless
+        anyhow::ensure!(
+            self.bit_width <= w,
+            "bit_width {} exceeds the word width {w}",
+            self.bit_width
+        );
+        anyhow::ensure!(
+            self.mask == mask::<B::Word>(self.bit_width),
+            "cached mask does not match bit_width {}",
+            self.bit_width
+        );
+        anyhow::ensure!(
+            self.len == 0 || !self.bits.as_ref().is_empty(),
+            "a non-empty vector needs at least one backing word (len = {})",
+            self.len
+        );
+        let needed = self
+            .len
+            .checked_mul(self.bit_width)
+            .ok_or_else(|| anyhow::anyhow!("length in bits (len * bit_width) overflows usize"))?;
+        let have = self
+            .bits
+            .as_ref()
+            .len()
+            .checked_mul(w)
+            .ok_or_else(|| anyhow::anyhow!("backing size in bits overflows usize"))?;
+        anyhow::ensure!(
+            have >= needed,
+            "backing storage holds {have} bits but {needed} are required for {} values of width {}",
+            self.len,
+            self.bit_width
+        );
+        Ok(())
+    }
+
     /// Like [`SliceByValue::index_value`], but using unaligned reads.
     ///
     /// This method can be used only for bit width smaller than or equal to
@@ -2204,6 +2247,74 @@ impl<'a, B: Backend<Word: Word> + AsRef<[B::Word]>> IntoUncheckedBackIterator
     }
 }
 
+/// Backing storage whose deserialization invariants can be validated.
+///
+/// A static function uses this, after deserializing from an untrusted source,
+/// to verify that an unchecked read of any index in `0..required_slots` stays
+/// within the backing.
+pub trait ValidateBacking {
+    /// Validates internal invariants and that indices in `0..required_slots`
+    /// are safe to read with the unchecked accessors.
+    fn validate_capacity(&self, required_slots: usize) -> anyhow::Result<()>;
+}
+
+impl<W: Word> ValidateBacking for Box<[W]> {
+    fn validate_capacity(&self, required_slots: usize) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.len() >= required_slots,
+            "backing slice holds {} values but {required_slots} are required",
+            self.len()
+        );
+        Ok(())
+    }
+}
+
+impl<B: Backend<Word: Word> + AsRef<[B::Word]>> ValidateBacking for BitFieldVec<B> {
+    fn validate_capacity(&self, required_slots: usize) -> anyhow::Result<()> {
+        self.validate()?;
+        if required_slots > 0 {
+            if self.bit_width == 0 {
+                // Any zero-width read hits word 0, so a single word suffices.
+                anyhow::ensure!(
+                    !self.bits.as_ref().is_empty(),
+                    "zero-width backing needs at least one word"
+                );
+            } else {
+                anyhow::ensure!(
+                    self.len >= required_slots,
+                    "backing holds {} values but {required_slots} are required",
+                    self.len
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<B: Backend<Word: Word> + AsRef<[B::Word]>> ValidateBacking for BitFieldVecU<B> {
+    fn validate_capacity(&self, required_slots: usize) -> anyhow::Result<()> {
+        self.0.validate_capacity(required_slots)?;
+        anyhow::ensure!(
+            test_unaligned!(B::Word, self.0.bit_width),
+            "bit width {} does not satisfy the constraints for unaligned reads",
+            self.0.bit_width
+        );
+        // Unaligned reads need a trailing padding word past the last value.
+        let w = B::Word::BITS as usize; // BITS <= 128, lossless
+        let needed_words = self
+            .0
+            .len
+            .checked_mul(self.0.bit_width)
+            .ok_or_else(|| anyhow::anyhow!("length in bits overflows usize"))?
+            .div_ceil(w);
+        anyhow::ensure!(
+            self.0.bits.as_ref().len() > needed_words,
+            "unaligned backing is missing its trailing padding word"
+        );
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2303,5 +2414,49 @@ mod tests {
                 assert_eq!(dest_actual, dest_expected);
             }
         }
+    }
+
+    #[test]
+    fn test_validate() {
+        // Builder-produced vectors are valid.
+        assert!(BitFieldVec::<Vec<usize>>::new(7, 100).validate().is_ok());
+        assert!(BitFieldVec::<Vec<usize>>::new(0, 0).validate().is_ok());
+        assert!(BitFieldVec::<Vec<usize>>::new(0, 5).validate().is_ok());
+
+        // bit_width exceeds the word width.
+        let bad = BitFieldVec::<Vec<usize>> {
+            bits: vec![0; 4],
+            bit_width: 65,
+            mask: usize::MAX,
+            len: 1,
+        };
+        assert!(bad.validate().is_err());
+
+        // mask inconsistent with bit_width.
+        let bad = BitFieldVec::<Vec<usize>> {
+            bits: vec![0; 4],
+            bit_width: 8,
+            mask: 0,
+            len: 1,
+        };
+        assert!(bad.validate().is_err());
+
+        // backing too small for len (100 * 10 = 1000 bits > 64).
+        let bad = BitFieldVec::<Vec<usize>> {
+            bits: vec![0; 1],
+            bit_width: 10,
+            mask: mask::<usize>(10),
+            len: 100,
+        };
+        assert!(bad.validate().is_err());
+
+        // Zero-width but non-empty needs at least one backing word.
+        let bad = BitFieldVec::<Vec<usize>> {
+            bits: vec![],
+            bit_width: 0,
+            mask: 0,
+            len: 5,
+        };
+        assert!(bad.validate().is_err());
     }
 }

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -252,6 +252,18 @@ fn mask<W: Word>(bit_width: usize) -> W {
     }
 }
 
+/// Computes `count * bit_width` (the number of bits needed to store `count`
+/// values of the given width), panicking on overflow. Used by the safe
+/// constructors and `resize` before the result sizes an allocation or guards
+/// an unchecked access; with `overflow-checks = false` a wrapping product
+/// would defeat those guards.
+#[inline]
+fn checked_bit_len(count: usize, bit_width: usize) -> usize {
+    count
+        .checked_mul(bit_width)
+        .expect("BitFieldVec length in bits (count * bit_width) overflows usize")
+}
+
 impl<B: Backend<Word: Word>> BitFieldVec<B> {
     /// Creates a new vector from the given backend, bit width, and length.
     ///
@@ -440,7 +452,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitFieldVec<B> {
     /// of bits available in the backend.
     pub fn wrap(backend: B, bit_width: usize, len: usize) -> BitFieldVec<B> {
         assert!(
-            len * bit_width <= backend.as_ref().len() * B::Word::BITS as usize,
+            checked_bit_len(len, bit_width) <= backend.as_ref().len() * B::Word::BITS as usize,
             "len * bit_width must be at most the number of bits in the backend"
         );
         assert!(
@@ -461,7 +473,10 @@ impl<W: Word> BitFieldVec<Vec<W>> {
     #[must_use]
     pub fn new(bit_width: usize, len: usize) -> Self {
         // We need at least one word to handle the case of bit width zero.
-        let n_of_words = Ord::max(1, (len * bit_width).div_ceil(W::BITS as usize));
+        let n_of_words = Ord::max(
+            1,
+            checked_bit_len(len, bit_width).div_ceil(W::BITS as usize),
+        );
         Self {
             bits: vec![W::ZERO; n_of_words],
             bit_width,
@@ -475,7 +490,10 @@ impl<W: Word> BitFieldVec<Vec<W>> {
     #[must_use]
     pub fn with_capacity(bit_width: usize, capacity: usize) -> Self {
         // We need at least one word to handle the case of bit width zero.
-        let n_of_words = Ord::max(1, (capacity * bit_width).div_ceil(W::BITS as usize));
+        let n_of_words = Ord::max(
+            1,
+            checked_bit_len(capacity, bit_width).div_ceil(W::BITS as usize),
+        );
         let mut bits = Vec::with_capacity(n_of_words);
         if bit_width == 0 {
             // A zero-width vector still needs one backing word so that
@@ -545,24 +563,31 @@ impl<W: Word> BitFieldVec<Vec<W>> {
     /// Adds a value at the end of the vector.
     pub fn push(&mut self, value: W) {
         panic_if_value!(value, self.mask, self.bit_width);
+        let next_len = self
+            .len
+            .checked_add(1)
+            .expect("BitFieldVec length overflows usize");
         if self.bits.is_empty()
-            || (self.len + 1) * self.bit_width > self.bits.len() * W::BITS as usize
+            || checked_bit_len(next_len, self.bit_width) > self.bits.len() * W::BITS as usize
         {
             self.bits.push(W::ZERO);
         }
+        // SAFETY: the grow above guarantees `self.bits` has a word covering the
+        // value at index `self.len` (which is `< next_len`), so this unchecked
+        // write stays in bounds.
         unsafe {
             self.set_value_unchecked(self.len, value);
         }
-        self.len += 1;
+        self.len = next_len;
     }
 
     /// Truncates or extends with `value` the vector.
     pub fn resize(&mut self, new_len: usize, value: W) {
         panic_if_value!(value, self.mask, self.bit_width);
         if new_len > self.len {
-            if new_len * self.bit_width > self.bits.len() * W::BITS as usize {
+            if checked_bit_len(new_len, self.bit_width) > self.bits.len() * W::BITS as usize {
                 self.bits.resize(
-                    (new_len * self.bit_width).div_ceil(W::BITS as usize),
+                    checked_bit_len(new_len, self.bit_width).div_ceil(W::BITS as usize),
                     W::ZERO,
                 );
             }
@@ -618,7 +643,7 @@ impl<W: Word> BitFieldVec<Box<[W]>> {
     ///
     /// [`TryIntoUnaligned`]: crate::traits::TryIntoUnaligned
     pub fn new_padded(bit_width: usize, len: usize) -> Self {
-        let n_of_words = (len * bit_width).div_ceil(W::BITS as usize);
+        let n_of_words = checked_bit_len(len, bit_width).div_ceil(W::BITS as usize);
         Self {
             bits: vec![W::ZERO; n_of_words + 1].into_boxed_slice(),
             bit_width,
@@ -817,11 +842,19 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
             self.bit_width, dst.bit_width
         );
         // Reduce len to the elements available in both vectors
-        let len = Ord::min(Ord::min(len, dst.len - to), self.len - from);
+        let len = Ord::min(
+            Ord::min(len, dst.len.saturating_sub(to)),
+            self.len.saturating_sub(from),
+        );
         if len == 0 {
             return;
         }
         let bit_width = Ord::min(self.bit_width, dst.bit_width);
+        if bit_width == 0 {
+            // Zero-width copy: all values are zero, nothing to move, and the
+            // `bit_len - 1` position math below would underflow.
+            return;
+        }
         let bit_len = len * bit_width;
         let src_pos = from * self.bit_width;
         let dst_pos = to * dst.bit_width;
@@ -1486,7 +1519,10 @@ impl<A: PrimitiveAtomicUnsigned<Value: Word>> AtomicBitFieldVec<Vec<A>> {
     #[must_use]
     pub fn new(bit_width: usize, len: usize) -> AtomicBitFieldVec<Vec<A>> {
         // we need at least two words to avoid branches in the gets
-        let n_of_words = Ord::max(1, (len * bit_width).div_ceil(A::Value::BITS as usize));
+        let n_of_words = Ord::max(
+            1,
+            checked_bit_len(len, bit_width).div_ceil(A::Value::BITS as usize),
+        );
         AtomicBitFieldVec {
             bits: (0..n_of_words).map(|_| A::new(A::Value::ZERO)).collect(),
             bit_width,

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -487,6 +487,12 @@ impl<'a, W: Word> Iterator for ChunksMut<'a, W> {
             next
         })
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Exact: one chunk per inner slice chunk.
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, W: Word> ExactSizeIterator for ChunksMut<'a, W> where

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -824,6 +824,21 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
         }
     }
 
+    fn apply_in_place<F>(&mut self, mut f: F)
+    where
+        F: FnMut(Self::Value) -> Self::Value,
+    {
+        for idx in 0..self.len {
+            // SAFETY: idx < self.len.
+            let value = unsafe { self.get_value_unchecked(idx) };
+            let new_value = f(value);
+            panic_if_value!(new_value, self.mask, self.bit_width);
+            // SAFETY: idx < self.len and new_value fits the bit width
+            // (checked just above).
+            unsafe { self.set_value_unchecked(idx, new_value) };
+        }
+    }
+
     unsafe fn set_value_unchecked(&mut self, index: usize, value: B::Word) {
         let bits = B::Word::BITS as usize;
         let pos = index * self.bit_width;

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -1019,24 +1019,48 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
             return;
         }
         let mask = self.mask;
-        let number_of_words: usize = self.bits.as_ref().len();
-        let last_word_idx = number_of_words.saturating_sub(1);
-
+        // Lossless: BITS <= 128 always fits usize.
         let bits = B::Word::BITS as usize;
+
+        // One element per word: the buffered paths below would shift by the
+        // word width, which is masked in release. The mask is all ones.
+        if bit_width == bits {
+            for i in 0..self.len {
+                // SAFETY: i < self.len and the backend holds at least
+                // ceil(len * bit_width / BITS) = len words (type invariant).
+                let value = *unsafe { self.bits.as_ref().get_unchecked(i) };
+                let new_value = f(value);
+                // SAFETY: same bound as the read above.
+                *unsafe { self.bits.as_mut().get_unchecked_mut(i) } = new_value;
+            }
+            return;
+        }
+
+        // Words containing logical elements. We must never invoke `f` on data
+        // beyond the logical end of the vector nor modify backing words (or
+        // bits) past it: the module contract states that storage outside the
+        // vector is not modified.
+        let logical_bits = self.len * bit_width;
+        let number_of_words = logical_bits.div_ceil(bits);
+        let last_word_idx = number_of_words - 1;
+        // Bits of the last logical word that belong to elements.
+        let mut buffer_limit = logical_bits % bits;
+        if buffer_limit == 0 {
+            buffer_limit = bits;
+        }
+
         let mut write_buffer: B::Word = B::Word::ZERO;
+        // SAFETY: the vector is nonempty with positive bit width, so the
+        // backend holds at least one word.
         let mut read_buffer: B::Word = *unsafe { self.bits.as_ref().get_unchecked(0) };
 
         // specialized case because it's much faster
         if bit_width.is_power_of_two() {
             let mut bits_in_buffer = 0;
 
-            let mut buffer_limit = (self.len() * bit_width) % bits;
-            if buffer_limit == 0 {
-                buffer_limit = bits;
-            }
-
             for read_idx in 1..number_of_words {
                 // pre-load the next word so it loads while we parse the buffer
+                // SAFETY: read_idx < number_of_words <= backend length.
                 let next_word: B::Word = *unsafe { self.bits.as_ref().get_unchecked(read_idx) };
 
                 // parse as much as we can from the buffer
@@ -1048,7 +1072,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
                     }
 
                     let value = read_buffer & mask;
-                    // throw away the bits we just read
+                    // throw away the bits we just read (bit_width < bits here)
                     read_buffer >>= bit_width;
                     // apply user func
                     let new_value = f(value);
@@ -1059,16 +1083,19 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
                 }
 
                 debug_assert_eq!(read_buffer, B::Word::ZERO);
+                // SAFETY: read_idx - 1 < number_of_words <= backend length.
                 *unsafe { self.bits.as_mut().get_unchecked_mut(read_idx - 1) } = write_buffer;
                 read_buffer = next_word;
                 write_buffer = B::Word::ZERO;
                 bits_in_buffer = 0;
             }
 
-            // write the last word if we have some bits left
+            // Process the elements of the last logical word, preserving any
+            // bits beyond the logical end of the vector.
+            let last_word_original = read_buffer;
             while bits_in_buffer < buffer_limit {
                 let value = read_buffer & mask;
-                // throw away the bits we just read
+                // throw away the bits we just read (bit_width < bits here)
                 read_buffer >>= bit_width;
                 // apply user func
                 let new_value = f(value);
@@ -1077,6 +1104,11 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
                 bits_in_buffer += bit_width;
             }
 
+            if buffer_limit != bits {
+                let tail_mask = B::Word::MAX << buffer_limit;
+                write_buffer |= last_word_original & tail_mask;
+            }
+            // SAFETY: last_word_idx < number_of_words <= backend length.
             *unsafe { self.bits.as_mut().get_unchecked_mut(last_word_idx) } = write_buffer;
             return;
         }
@@ -1092,7 +1124,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
         let mut lower_word_limit = 0;
         let mut upper_word_limit = bits;
 
-        // We iterate across the words
+        // We iterate across the words containing logical elements.
         for word_number in 0..last_word_idx {
             // We iterate across the elements in the word.
             while global_bit_index + bit_width <= upper_word_limit {
@@ -1109,6 +1141,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
             }
 
             // We retrieve the next word from the bitvec.
+            // SAFETY: word_number + 1 <= last_word_idx < backend length.
             let next_word = *unsafe { self.bits.as_ref().get_unchecked(word_number + 1) };
 
             let mut new_write_buffer = B::Word::ZERO;
@@ -1130,6 +1163,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
 
             read_buffer = next_word;
 
+            // SAFETY: word_number < last_word_idx < backend length.
             *unsafe { self.bits.as_mut().get_unchecked_mut(word_number) } = write_buffer;
 
             write_buffer = new_write_buffer;
@@ -1139,7 +1173,8 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
 
         let mut offset = global_bit_index - lower_word_limit;
 
-        // We iterate across the elements in the word.
+        // We iterate across the elements entirely contained in the last
+        // logical word.
         while offset < self.len() * bit_width - global_bit_index {
             // We retrieve the value from the current word.
             let element = self.mask & (read_buffer >> offset);
@@ -1152,6 +1187,12 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + AsMut<[B::Word]>> SliceByValueM
             offset += bit_width;
         }
 
+        // Preserve any bits beyond the logical end of the vector.
+        if buffer_limit != bits {
+            let tail_mask = B::Word::MAX << buffer_limit;
+            write_buffer |= read_buffer & tail_mask;
+        }
+        // SAFETY: last_word_idx < number_of_words <= backend length.
         *unsafe { self.bits.as_mut().get_unchecked_mut(last_word_idx) } = write_buffer;
     }
 
@@ -1250,7 +1291,12 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> crate::traits::UncheckedIterator
         if self.fill >= bit_width {
             self.fill -= bit_width;
             let res = self.window & self.vec.mask;
-            self.window >>= bit_width;
+            self.window = if bit_width == B::Word::BITS as usize {
+                // A shift by the word width would be masked in release.
+                B::Word::ZERO
+            } else {
+                self.window >> bit_width
+            };
             return res;
         }
 
@@ -1259,7 +1305,13 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> crate::traits::UncheckedIterator
         self.window = *unsafe { self.vec.bits.as_ref().get_unchecked(self.word_index) };
         let res = (res | (self.window << self.fill)) & self.vec.mask;
         let used = bit_width - self.fill;
-        self.window >>= used;
+        self.window = if used == B::Word::BITS as usize {
+            // Happens for bit_width == B::Word::BITS and an empty window:
+            // a shift by the word width would be masked in release.
+            B::Word::ZERO
+        } else {
+            self.window >> used
+        };
         self.fill = B::Word::BITS as usize - used; // not in a loop
         res
     }
@@ -1332,9 +1384,18 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> crate::traits::UncheckedIterator
         self.word_index -= 1;
         self.window = *unsafe { self.vec.bits.as_ref().get_unchecked(self.word_index) };
         let used = bit_width - self.fill;
-        res = ((res << used) | (self.window >> (B::Word::BITS as usize - used))) & self.vec.mask; // not in a loop
-        self.window <<= used;
-        self.fill = B::Word::BITS as usize - used;
+        if used == B::Word::BITS as usize {
+            // The freshly loaded word is exactly the element (bit_width ==
+            // B::Word::BITS, empty window): the generic combine below would
+            // shift by the word width, which is masked in release.
+            res = self.window & self.vec.mask;
+            self.window = B::Word::ZERO;
+            self.fill = 0;
+        } else {
+            res = ((res << used) | (self.window >> (B::Word::BITS as usize - used))) & self.vec.mask; // not in a loop
+            self.window <<= used;
+            self.fill = B::Word::BITS as usize - used;
+        }
         res
     }
 }

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -264,6 +264,19 @@ fn checked_bit_len(count: usize, bit_width: usize) -> usize {
         .expect("BitFieldVec length in bits (count * bit_width) overflows usize")
 }
 
+/// Maps a store/RMW `Ordering` to a valid ordering for the internal atomic
+/// *load* and the compare-exchange *failure* slot, both of which reject
+/// `Release`/`AcqRel`: `Release` -> `Relaxed`, `AcqRel` -> `Acquire`, others
+/// unchanged. The success slot keeps the caller's requested ordering.
+#[inline]
+fn load_ordering(order: Ordering) -> Ordering {
+    match order {
+        Ordering::Release => Ordering::Relaxed,
+        Ordering::AcqRel => Ordering::Acquire,
+        other => other,
+    }
+}
+
 impl<B: Backend<Word: Word>> BitFieldVec<B> {
     /// Creates a new vector from the given backend, bit width, and length.
     ///
@@ -1627,22 +1640,24 @@ impl<B: Backend<Word: PrimitiveAtomicUnsigned<Value: Word>> + AsRef<[B::Word]>>
 
             if bit_index + self.bit_width <= wbits {
                 // this is consistent
-                let mut current = data.get_unchecked(word_index).load(order);
+                let mut current = data.get_unchecked(word_index).load(load_ordering(order));
                 loop {
                     let mut new = current;
                     new &= !(self.mask << bit_index);
                     new |= value << bit_index;
 
-                    match data
-                        .get_unchecked(word_index)
-                        .compare_exchange(current, new, order, order)
-                    {
+                    match data.get_unchecked(word_index).compare_exchange(
+                        current,
+                        new,
+                        order,
+                        load_ordering(order),
+                    ) {
                         Ok(_) => break,
                         Err(e) => current = e,
                     }
                 }
             } else {
-                let mut word = data.get_unchecked(word_index).load(order);
+                let mut word = data.get_unchecked(word_index).load(load_ordering(order));
                 // try to wait for the other thread to finish
                 fence(Ordering::Acquire);
                 loop {
@@ -1651,10 +1666,12 @@ impl<B: Backend<Word: PrimitiveAtomicUnsigned<Value: Word>> + AsRef<[B::Word]>>
                         - <B::Word as PrimitiveAtomic>::Value::ONE;
                     new |= value << bit_index;
 
-                    match data
-                        .get_unchecked(word_index)
-                        .compare_exchange(word, new, order, order)
-                    {
+                    match data.get_unchecked(word_index).compare_exchange(
+                        word,
+                        new,
+                        order,
+                        load_ordering(order),
+                    ) {
                         Ok(_) => break,
                         Err(e) => word = e,
                     }
@@ -1668,17 +1685,21 @@ impl<B: Backend<Word: PrimitiveAtomicUnsigned<Value: Word>> + AsRef<[B::Word]>>
                 // should try to synchronize the threads as much as possible
                 compiler_fence(Ordering::SeqCst);
 
-                let mut word = data.get_unchecked(word_index + 1).load(order);
+                let mut word = data
+                    .get_unchecked(word_index + 1)
+                    .load(load_ordering(order));
                 fence(Ordering::Acquire);
                 loop {
                     let mut new = word;
                     new &= !(self.mask >> (wbits - bit_index));
                     new |= value >> (wbits - bit_index);
 
-                    match data
-                        .get_unchecked(word_index + 1)
-                        .compare_exchange(word, new, order, order)
-                    {
+                    match data.get_unchecked(word_index + 1).compare_exchange(
+                        word,
+                        new,
+                        order,
+                        load_ordering(order),
+                    ) {
                         Ok(_) => break,
                         Err(e) => word = e,
                     }

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -444,7 +444,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitFieldVec<B> {
             "len * bit_width must be at most the number of bits in the backend"
         );
         assert!(
-            backend.as_ref().len() > 0 || bit_width == 0,
+            !backend.as_ref().is_empty() || bit_width == 0,
             "backend must have at least one word when bit width is zero and len is nonzero"
         );
         BitFieldVec {

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -444,7 +444,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitFieldVec<B> {
             "len * bit_width must be at most the number of bits in the backend"
         );
         assert!(
-            !backend.as_ref().is_empty() || bit_width == 0,
+            !backend.as_ref().is_empty() || len == 0,
             "backend must have at least one word when bit width is zero and len is nonzero"
         );
         BitFieldVec {
@@ -476,8 +476,14 @@ impl<W: Word> BitFieldVec<Vec<W>> {
     pub fn with_capacity(bit_width: usize, capacity: usize) -> Self {
         // We need at least one word to handle the case of bit width zero.
         let n_of_words = Ord::max(1, (capacity * bit_width).div_ceil(W::BITS as usize));
+        let mut bits = Vec::with_capacity(n_of_words);
+        if bit_width == 0 {
+            // A zero-width vector still needs one backing word so that
+            // `set_value_unchecked` can index word 0.
+            bits.push(W::ZERO);
+        }
         Self {
-            bits: Vec::with_capacity(n_of_words),
+            bits,
             bit_width,
             mask: mask(bit_width),
             len: 0,
@@ -539,7 +545,9 @@ impl<W: Word> BitFieldVec<Vec<W>> {
     /// Adds a value at the end of the vector.
     pub fn push(&mut self, value: W) {
         panic_if_value!(value, self.mask, self.bit_width);
-        if (self.len + 1) * self.bit_width > self.bits.len() * W::BITS as usize {
+        if self.bits.is_empty()
+            || (self.len + 1) * self.bit_width > self.bits.len() * W::BITS as usize
+        {
             self.bits.push(W::ZERO);
         }
         unsafe {
@@ -557,6 +565,10 @@ impl<W: Word> BitFieldVec<Vec<W>> {
                     (new_len * self.bit_width).div_ceil(W::BITS as usize),
                     W::ZERO,
                 );
+            }
+            if self.bits.is_empty() {
+                // Zero-width vector: still needs one backing word.
+                self.bits.push(W::ZERO);
             }
             for i in self.len..new_len {
                 unsafe {

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -1564,6 +1564,22 @@ impl<'a, B: Backend<Word: Word> + AsRef<[B::Word]>> IntoIteratorFrom for &'a Bit
 
 impl<W: Word> core::iter::Extend<W> for BitFieldVec<Vec<W>> {
     fn extend<T: IntoIterator<Item = W>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        // Reserve for the lower bound of the incoming iterator to avoid
+        // repeated word reallocation. Best-effort: skip the hint if the total
+        // bit length would overflow (`push` would then panic anyway).
+        // `W::BITS as usize` is a lossless widen.
+        let (lo, _) = iter.size_hint();
+        if self.bit_width != 0 {
+            if let Some(needed_words) = self
+                .len
+                .checked_add(lo)
+                .and_then(|total| total.checked_mul(self.bit_width))
+                .map(|bits| bits.div_ceil(W::BITS as usize))
+            {
+                self.bits.reserve(needed_words.saturating_sub(self.bits.len()));
+            }
+        }
         for value in iter {
             self.push(value);
         }

--- a/src/bits/bit_field_vec.rs
+++ b/src/bits/bit_field_vec.rs
@@ -2170,14 +2170,10 @@ impl<W: Word> crate::traits::TryIntoUnaligned for BitFieldVec<Box<[W]>> {
     ) -> Result<Self::Unaligned, crate::traits::UnalignedConversionError> {
         let bw = self.bit_width();
         if !test_unaligned!(W, bw) {
-            return Err(crate::traits::UnalignedConversionError(format!(
-                "bit width {} does not satisfy the constraints for unaligned reads on word type {} (must be <= {}, or == {}, or == {})",
-                bw,
-                stringify!(W),
-                W::BITS as usize - 6,
-                W::BITS as usize - 4,
-                W::BITS as usize,
-            )));
+            return Err(crate::traits::UnalignedConversionError::InvalidBitWidth {
+                bit_width: bw,
+                word_bits: W::BITS,
+            });
         }
         let needed = (SliceByValue::len(&self) * bw).div_ceil(W::BITS as usize);
         if self.as_slice().len() > needed {

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -795,6 +795,12 @@ impl<'a, W: Word> Iterator for BitVecChunksMut<'a, W> {
             next
         })
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Exact: one chunk per inner slice chunk.
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, W: Word> ExactSizeIterator for BitVecChunksMut<'a, W> where

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -604,6 +604,11 @@ impl<W: Word> BitVec<Box<[W]>> {
 
 impl<W: Word> Extend<bool> for BitVec<Vec<W>> {
     fn extend<T: IntoIterator<Item = bool>>(&mut self, i: T) {
+        let i = i.into_iter();
+        // Reserve for the lower bound (one bit per element) to avoid repeated
+        // word reallocation.
+        let (lo, _) = i.size_hint();
+        self.reserve(lo);
         for b in i {
             self.push(b);
         }

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -612,11 +612,14 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitVecValueOps<B::Word> for BitV
             width,
             B::Word::BITS
         );
+        let end = pos
+            .checked_add(width)
+            .expect("bit range end (pos + width) overflows usize");
         assert!(
-            pos + width <= self.len,
+            end <= self.len,
             "bit range {}..{} out of bounds for length {}",
             pos,
-            pos + width,
+            end,
             self.len
         );
         // Disambiguate: `SliceByValue::get_value_unchecked` now also

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -402,7 +402,8 @@ impl<W: Word> BitVec<Vec<W>> {
     ///
     /// # Panics
     ///
-    /// Panics if `width` > `W::BITS`.
+    /// Panics if `width` > `W::BITS`, or if the resulting bit length
+    /// overflows `usize`.
     pub fn append_value(&mut self, value: W, width: usize) {
         assert!(
             width <= W::BITS as usize,
@@ -416,7 +417,10 @@ impl<W: Word> BitVec<Vec<W>> {
         let bits_per_word = W::BITS as usize;
         let l = bits_per_word - width;
         let value = (value << l) >> l;
-        let new_len = self.len + width;
+        let new_len = self
+            .len
+            .checked_add(width)
+            .expect("bit length overflows usize");
         let needed_words = new_len.div_ceil(bits_per_word);
         // Grow the backing storage if necessary.
         self.bits.resize(needed_words, W::ZERO);
@@ -451,8 +455,16 @@ impl<W: Word> BitVec<Vec<W>> {
     /// `self.len() + additional`. The allocator may reserve more space to
     /// speculatively avoid frequent reallocations. Does nothing if the
     /// capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resulting bit length overflows `usize`.
     pub fn reserve(&mut self, additional: usize) {
-        let needed_words = (self.len + additional).div_ceil(W::BITS as usize);
+        let needed_words = self
+            .len
+            .checked_add(additional)
+            .expect("bit length overflows usize")
+            .div_ceil(W::BITS as usize);
         self.bits
             .reserve(needed_words.saturating_sub(self.bits.len()));
     }
@@ -467,8 +479,16 @@ impl<W: Word> BitVec<Vec<W>> {
     /// Note that the allocator may give the collection more space than it
     /// requests. Therefore, capacity cannot be relied upon to be precisely
     /// minimal.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resulting bit length overflows `usize`.
     pub fn reserve_exact(&mut self, additional: usize) {
-        let needed_words = (self.len + additional).div_ceil(W::BITS as usize);
+        let needed_words = self
+            .len
+            .checked_add(additional)
+            .expect("bit length overflows usize")
+            .div_ceil(W::BITS as usize);
         self.bits
             .reserve_exact(needed_words.saturating_sub(self.bits.len()));
     }

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -68,10 +68,10 @@
 //! # Slice-by-value support
 //!
 //! [`BitVec`] implement the [`BitFieldSlice`]/[`BitFieldSliceMut`] traits as a
-//! bit-field slice of width one. Note that the methods [`get_value`] and
-//! [`get_value_unchecked`] of [`SliceByValue`] conflicts with those of
-//! [`BitVecValueOps`], so if you absolutely need to pull in both traits you
-//! have to disambiguate the method calls. Moreover, as part of [`SliceByValueMut`]
+//! bit-field slice of width one. [`BitVecValueOps`] provides bit-range
+//! accessors (`get_bits`/`get_bits_unchecked`) whose names are distinct from
+//! the index-based [`get_value`]/[`get_value_unchecked`] of [`SliceByValue`],
+//! so the two traits can be pulled in together without disambiguation. Moreover, as part of [`SliceByValueMut`]
 //! you can also obtain [mutable chunks] from a bit vector, provided they are
 //! aligned enough.
 //!
@@ -605,7 +605,7 @@ impl<B: ToOwned> BitVec<B> {
 }
 
 impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitVecValueOps<B::Word> for BitVec<B> {
-    fn get_value(&self, pos: usize, width: usize) -> B::Word {
+    fn get_bits(&self, pos: usize, width: usize) -> B::Word {
         assert!(
             width <= B::Word::BITS as usize,
             "width {} must be at most W::BITS ({})",
@@ -622,13 +622,13 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitVecValueOps<B::Word> for BitV
             end,
             self.len
         );
-        // Disambiguate: `SliceByValue::get_value_unchecked` now also
-        // exists for `BitVec`, but with a different signature.
-        unsafe { <Self as BitVecValueOps<B::Word>>::get_value_unchecked(self, pos, width) }
+        // SAFETY: the assertions above guarantee `pos + width <= self.len` and
+        // `width <= W::BITS`, satisfying the contract of `get_bits_unchecked`.
+        unsafe { self.get_bits_unchecked(pos, width) }
     }
 
     #[inline]
-    unsafe fn get_value_unchecked(&self, pos: usize, width: usize) -> B::Word {
+    unsafe fn get_bits_unchecked(&self, pos: usize, width: usize) -> B::Word {
         let bits = B::Word::BITS as usize;
         let word_index = pos / bits;
         let bit_index = pos % bits;
@@ -1361,12 +1361,12 @@ impl<W: Word> crate::traits::TryIntoUnaligned for BitVec<Box<[W]>> {
 
 impl<B: Backend<Word: Word> + AsRef<[B::Word]>> BitVecValueOps<B::Word> for BitVecU<B> {
     #[inline(always)]
-    fn get_value(&self, pos: usize, width: usize) -> B::Word {
+    fn get_bits(&self, pos: usize, width: usize) -> B::Word {
         self.0.get_value_unaligned(pos, width)
     }
 
     #[inline(always)]
-    unsafe fn get_value_unchecked(&self, pos: usize, width: usize) -> B::Word {
+    unsafe fn get_bits_unchecked(&self, pos: usize, width: usize) -> B::Word {
         unsafe { self.0.get_value_unaligned_unchecked(pos, width) }
     }
 }

--- a/src/bits/bit_vec.rs
+++ b/src/bits/bit_vec.rs
@@ -27,8 +27,12 @@
 //!   not resizable) bit vector.
 //!
 //! Note that nothing is assumed about the content of the backend outside the
-//! bits of the bit vector. Moreover, the content of the backend outside of
-//! the bit vector is never modified by the methods of this structure.
+//! bits of the bit vector. Query and count methods never depend on it, and
+//! growth operations that write into the last touched word (for example
+//! [`resize`] filling with `true`) may set backend bits beyond the logical
+//! length within that word; only bits past the allocation are never touched.
+//!
+//! [`resize`]: BitVec::resize
 //!
 //! It is possible to juggle between all flavors using [`From`]/[`Into`], and
 //! with [`TryFrom`]/[`TryInto`] when going [from a non-atomic to an atomic bit vector].

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -91,7 +91,8 @@ pub(crate) use test_unaligned;
 macro_rules! test_unaligned_pos {
     ($ty:ty, $pos:expr, $bw:expr) => {{
         let bits = <$ty>::BITS as usize;
-        $bw + (($pos as usize) & 7) <= bits
+        let bw = $bw;
+        bw <= bits && (($pos as usize) & 7) <= bits - bw
     }};
 }
 
@@ -106,7 +107,8 @@ pub(crate) use test_unaligned_pos;
 macro_rules! test_unaligned_any_pos {
     ($ty:ty, $bw:expr) => {{
         let bits = <$ty>::BITS as usize;
-        $bw + 7 <= bits
+        let bw = $bw;
+        bw <= bits - 7
     }};
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,9 @@ pub fn read_concat_lines(filename: &str, n: usize) -> anyhow::Result<(String, Ve
     use lender::FallibleLender;
 
     let mut buffer = String::new();
-    let mut offsets: Vec<usize> = Vec::with_capacity(n.saturating_add(1));
+    // Cap the initial capacity: the default parallel path passes n = usize::MAX
+    // (read until EOF); the Vec grows naturally past the cap.
+    let mut offsets: Vec<usize> = Vec::with_capacity(n.min(1 << 20).saturating_add(1));
     offsets.push(0);
     let mut lender = crate::utils::DekoBufLineLender::from_path(filename)?;
     let mut count = 0usize;
@@ -249,4 +251,23 @@ pub struct LogIntervalArg {
     /// interpreted as milliseconds. Examples: "10s", "1m30s", "500".​
     #[arg(long, value_parser = parse_duration, default_value = "10s")]
     pub log_interval: Duration,
+}
+
+#[cfg(all(test, feature = "deko"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_concat_lines_unbounded_n() {
+        // The default parallel path passes n = usize::MAX; the initial capacity
+        // must be capped so this does not abort with a capacity overflow.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keys.txt");
+        std::fs::write(&path, "alpha\nbeta\ngamma\n").unwrap();
+        let (_buffer, offsets) = read_concat_lines(path.to_str().unwrap(), usize::MAX).unwrap();
+        // Three lines -> four monotone offsets, starting at 0.
+        assert_eq!(offsets.len(), 4);
+        assert_eq!(offsets[0], 0);
+        assert!(offsets.windows(2).all(|w| w[0] <= w[1]));
+    }
 }

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -2673,6 +2673,11 @@ where
     /// - All indices must be distinct.
     /// - All values must be smaller than or equal to `u`.
     /// - All indices must be smaller than `n`.
+    /// - Values must be nondecreasing with respect to their indices: for
+    ///   `i < j`, the value set at index `i` must be less than or equal to the
+    ///   value set at index `j`. Otherwise, high bits can collide or appear
+    ///   out of order, and the resulting structure is invalid even though all
+    ///   other conditions hold.
     /// - You must call this function exactly `n` times.
     #[inline]
     pub unsafe fn set(&self, index: usize, value: V)
@@ -2716,6 +2721,21 @@ where
         let high_bits: BitVec<Box<[usize]>> = self.high_bits.into();
         let low_bits: BitFieldVec<Vec<V>> = self.low_bits.into();
         let low_bits: BitFieldVec<Box<[V]>> = low_bits.into();
+
+        // A nonmonotone (or colliding) assignment through `set` produces a
+        // high-bits array whose number of ones differs from `n`; catch it
+        // here before the endpoint scans below run off the words.
+        debug_assert_eq!(
+            high_bits
+                .as_ref()
+                .iter()
+                // Lossless: count_ones of a word fits usize.
+                .map(|w| w.count_ones() as usize)
+                .sum::<usize>(),
+            self.n,
+            "the high-bits array does not contain exactly n ones: \
+             EliasFanoConcurrentBuilder::set was called with nonmonotone values"
+        );
 
         let (first_val, last_val) = if self.n == 0 {
             (V::MAX, V::MIN)

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -671,7 +671,10 @@ where
 
     #[inline(always)]
     fn into_iter_back_from(self, from: usize) -> EliasFanoBackIter<'a, V, H, L> {
-        self.iter_back_from(from + 1)
+        self.iter_back_from(
+            from.checked_add(1)
+                .expect("position overflow in into_iter_back_from"),
+        )
     }
 }
 

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -2626,6 +2626,8 @@ where
     l: usize,
     low_bits: AtomicBitFieldVec<Vec<Atomic<V>>>,
     high_bits: AtomicBitVec,
+    /// Number of `set` calls, checked against `n` in `build`.
+    count: std::sync::atomic::AtomicUsize,
 }
 
 impl<V: Word + AtomicPrimitive + PrimitiveNumberAs<u128>> EliasFanoConcurrentBuilder<V>
@@ -2658,6 +2660,7 @@ where
             l,
             low_bits: AtomicBitFieldVec::<Vec<Atomic<V>>>::new(l, n),
             high_bits: AtomicBitVec::new(num_high_bits),
+            count: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -2683,6 +2686,7 @@ where
 
         let high = (value >> self.l).as_to::<usize>() + index;
         self.high_bits.set(high, true, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Builds an Elias–Fano structure.
@@ -2700,6 +2704,12 @@ where
     /// [`build_with_seq`]: EliasFanoConcurrentBuilder::build_with_seq
     #[must_use]
     pub fn build(self) -> EliasFano<V> {
+        assert!(
+            self.count.load(Ordering::Relaxed) == self.n,
+            "EliasFanoConcurrentBuilder::set must be called exactly n times before build (n = {}, got {})",
+            self.n,
+            self.count.load(Ordering::Relaxed)
+        );
         let high_bits: BitVec<Box<[usize]>> = self.high_bits.into();
         let low_bits: BitFieldVec<Vec<V>> = self.low_bits.into();
         let low_bits: BitFieldVec<Box<[V]>> = low_bits.into();

--- a/src/dict/elias_fano.rs
+++ b/src/dict/elias_fano.rs
@@ -382,6 +382,139 @@ impl<V, H, L> EliasFano<V, H, L> {
     }
 }
 
+impl<
+    V: Word + PrimitiveNumberAs<usize>,
+    H: AsRef<[usize]> + BitLength,
+    L: SliceByValue<Value = V> + BitWidth,
+> EliasFano<V, H, L>
+{
+    /// Checks the representational invariants of this structure.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: the safe accessors otherwise trust `n`, `l`,
+    /// and the low/high-bits arrays, and reach unchecked selection on
+    /// malformed input.
+    ///
+    /// The check decodes the whole sequence once (`O(n)`), verifying counts,
+    /// monotonicity, the upper bound, and the cached endpoints. It does *not*
+    /// verify the inventories of selection wrappers (e.g. [`EfSeq`]): for
+    /// fully untrusted data, validate the representation and rebuild the
+    /// wrappers with [`map_high_bits`](EliasFano::map_high_bits).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        // Lossless: BITS <= 128 always fits usize.
+        let v_bits = V::BITS as usize;
+        let word_bits = usize::BITS as usize;
+        anyhow::ensure!(
+            self.l < v_bits,
+            "number of lower bits {} out of range for value type of {v_bits} bits",
+            self.l
+        );
+        anyhow::ensure!(
+            self.low_bits.len() == self.n,
+            "the lower-bits array has {} elements instead of {}",
+            self.low_bits.len(),
+            self.n
+        );
+        anyhow::ensure!(
+            self.low_bits.bit_width() == self.l,
+            "the lower-bits array has bit width {} instead of {}",
+            self.low_bits.bit_width(),
+            self.l
+        );
+        let shifted = self.u >> self.l;
+        let max_high = shifted.as_to::<usize>();
+        // Round-trip equality proves the conversion was lossless (for wide
+        // value types the high universe might not fit a usize).
+        anyhow::ensure!(
+            V::as_from(max_high) == shifted,
+            "the high universe {shifted} does not fit a usize"
+        );
+        let expected_high_len = self
+            .n
+            .checked_add(max_high)
+            .and_then(|x| x.checked_add(1))
+            .ok_or_else(|| anyhow::anyhow!("the high-bits length overflows usize"))?;
+        anyhow::ensure!(
+            self.high_bits.len() == expected_high_len,
+            "the high-bits array has {} bits instead of {}",
+            self.high_bits.len(),
+            expected_high_len
+        );
+        let words = self.high_bits.as_ref();
+        let len = self.high_bits.len();
+        anyhow::ensure!(
+            words.len() >= len.div_ceil(word_bits),
+            "the high-bits backend has {} words, too few for {} bits",
+            words.len(),
+            len
+        );
+
+        // Walk the ones of the logical high bits, decoding each value.
+        let mut ones = 0;
+        let mut prev = V::ZERO;
+        let mut first = V::MAX;
+        let mut last = V::MIN;
+        for (word_idx, &raw) in words.iter().enumerate().take(len.div_ceil(word_bits)) {
+            let mut word = raw;
+            let residual = len - word_idx * word_bits;
+            if residual < word_bits {
+                // Mask padding bits beyond the logical length.
+                word &= (1usize << residual) - 1;
+            }
+            while word != 0 {
+                // Lossless: trailing_zeros of a word fits usize.
+                let pos = word_idx * word_bits + word.trailing_zeros() as usize;
+                anyhow::ensure!(
+                    ones < self.n,
+                    "the high bits contain more than {} ones",
+                    self.n
+                );
+                // The k-th one at position pos encodes high part pos - k;
+                // pos >= ones because the previous `ones` ones occupy
+                // distinct earlier positions.
+                let high = pos - ones;
+                anyhow::ensure!(
+                    high <= max_high,
+                    "the high part {high} of element {ones} exceeds the maximum {max_high}"
+                );
+                let value = (V::as_from(high) << self.l) | self.low_bits.index_value(ones);
+                anyhow::ensure!(
+                    value <= self.u,
+                    "element {ones} is {value}, larger than the upper bound {}",
+                    self.u
+                );
+                anyhow::ensure!(
+                    ones == 0 || value >= prev,
+                    "element {ones} is {value}, smaller than its predecessor {prev}"
+                );
+                if ones == 0 {
+                    first = value;
+                }
+                last = value;
+                prev = value;
+                ones += 1;
+                word &= word - 1;
+            }
+        }
+        anyhow::ensure!(
+            ones == self.n,
+            "the high bits contain {ones} ones instead of {}",
+            self.n
+        );
+        anyhow::ensure!(
+            self.first_val == first,
+            "the cached first value {} does not match the decoded first value {first}",
+            self.first_val
+        );
+        anyhow::ensure!(
+            self.last_val == last,
+            "the cached last value {} does not match the decoded last value {last}",
+            self.last_val
+        );
+        Ok(())
+    }
+}
+
 impl<V: Word + PrimitiveNumberAs<usize>, H: AsRef<[usize]>, L: SliceByValue<Value = V>> Types
     for EliasFano<V, H, L>
 {
@@ -2849,5 +2982,74 @@ impl<V: Word, H> From<Unaligned<EliasFano<V, H, BitFieldVec<Box<[V]>>>>>
             low_bits: ef.low_bits.into(),
             high_bits: ef.high_bits,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_ef() -> EliasFano<usize> {
+        let mut efb = EliasFanoBuilder::new(4, 10);
+        for v in [0usize, 2, 8, 10] {
+            efb.push(v);
+        }
+        efb.build()
+    }
+
+    #[test]
+    fn test_validate() -> anyhow::Result<()> {
+        let ef = valid_ef();
+        ef.validate()?;
+
+        // Empty sequence.
+        let efb = EliasFanoBuilder::<usize>::new(0, 0);
+        efb.build().validate()?;
+
+        // Duplicates are allowed.
+        let mut efb = EliasFanoBuilder::new(3, 5);
+        for v in [2usize, 2, 5] {
+            efb.push(v);
+        }
+        efb.build().validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_rejects_corrupt() {
+        // Forged n: more elements than ones in the high bits.
+        let mut ef = valid_ef();
+        ef.n = 5;
+        assert!(ef.validate().is_err());
+
+        // Out-of-range number of lower bits.
+        let mut ef = valid_ef();
+        ef.l = usize::BITS as usize;
+        assert!(ef.validate().is_err());
+
+        // Cached endpoints not matching the decoded sequence.
+        let mut ef = valid_ef();
+        ef.first_val = 1;
+        assert!(ef.validate().is_err());
+        let mut ef = valid_ef();
+        ef.last_val = 9;
+        assert!(ef.validate().is_err());
+
+        // Upper bound smaller than the stored values.
+        let mut ef = valid_ef();
+        ef.u = 3;
+        assert!(ef.validate().is_err());
+
+        // High bits with a cleared one (count mismatch).
+        let mut ef = valid_ef();
+        let mut words: Vec<usize> = ef.high_bits.as_ref().to_vec();
+        let w0 = words[0];
+        words[0] = w0 & (w0 - 1); // clear the lowest one
+        // SAFETY: same backend word count and bit length as the original
+        // vector; we deliberately build an *invalid* EF representation to
+        // exercise validate(), never its accessors.
+        ef.high_bits =
+            unsafe { BitVec::from_raw_parts(words.into_boxed_slice(), ef.high_bits.len()) };
+        assert!(ef.validate().is_err());
     }
 }

--- a/src/dict/mapped_rear_coded_list.rs
+++ b/src/dict/mapped_rear_coded_list.rs
@@ -367,6 +367,12 @@ where
     /// Creates a new lender over the rear-coded list starting from the given
     /// position.
     pub fn new_from(prcl: &'a MappedRearCodedList<I, O, D, P, Q, SORTED>, from: usize) -> Self {
+        assert!(
+            from <= prcl.len(),
+            "Index out of bounds: {} > {}",
+            from,
+            prcl.len()
+        );
         Self {
             prcl,
             buffer: Vec::with_capacity(128),

--- a/src/dict/mapped_rear_coded_list.rs
+++ b/src/dict/mapped_rear_coded_list.rs
@@ -136,7 +136,9 @@ impl<
     ///
     /// It is your responsibility to ensure that the mapping is valid,
     /// that is, that its length matches the length of the rear-coded list,
-    /// and that all indices are in range.
+    /// and that all indices are in range. For parts coming from an untrusted
+    /// or possibly stale source, check the result with
+    /// [`validate`](MappedRearCodedList::validate) before use.
     ///
     /// # Panics
     ///
@@ -158,6 +160,33 @@ impl<
         (self.rcl, self.map)
     }
 
+    /// Checks that every mapping entry is a valid index into the underlying
+    /// rear-coded list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method (or the variant-specific `validate`, which also checks the
+    /// underlying list) before use: the safe accessors otherwise pass mapping
+    /// values to unchecked list accessors.
+    pub fn validate_map(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.map.len() == self.rcl.len(),
+            "mapping length {} does not match the list length {}",
+            self.map.len(),
+            self.rcl.len()
+        );
+        // `Q` only guarantees indexed access (`SliceByValue`), so we cannot
+        // iterate it directly.
+        for index in 0..self.map.len() {
+            let mapped = self.map.index_value(index);
+            anyhow::ensure!(
+                mapped < self.rcl.len(),
+                "mapping entry {index} is {mapped}, beyond the list length {}",
+                self.rcl.len()
+            );
+        }
+        Ok(())
+    }
+
     /// Returns the number of elements.
     ///
     /// This method is equivalent to [`IndexedSeq::len`], but it is provided to
@@ -173,6 +202,42 @@ impl<
     fn get_in_place_impl(&self, index: usize, result: &mut Vec<u8>) {
         let index = self.map.index_value(index);
         self.rcl.get_in_place_impl(index, result)
+    }
+}
+
+impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, Q: SliceByValue<Value = usize>, const SORTED: bool>
+    MappedRearCodedList<str, O, D, P, Q, SORTED>
+{
+    /// Checks the structural invariants of the mapping and of the underlying
+    /// rear-coded list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use.
+    pub fn validate(&self) -> anyhow::Result<()>
+    where
+        str: PartialEq<O>,
+        O: PartialEq<str> + PartialEq,
+    {
+        self.rcl.validate()?;
+        self.validate_map()
+    }
+}
+
+impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, Q: SliceByValue<Value = usize>, const SORTED: bool>
+    MappedRearCodedList<[u8], O, D, P, Q, SORTED>
+{
+    /// Checks the structural invariants of the mapping and of the underlying
+    /// rear-coded list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use.
+    pub fn validate(&self) -> anyhow::Result<()>
+    where
+        [u8]: PartialEq<O>,
+        O: PartialEq<[u8]> + PartialEq,
+    {
+        self.rcl.validate()?;
+        self.validate_map()
     }
 }
 

--- a/src/dict/rear_coded_list.rs
+++ b/src/dict/rear_coded_list.rs
@@ -566,11 +566,12 @@ impl<D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
     /// Returns in place the string of given index by writing
     /// its bytes into the provided string.
     pub fn get_in_place(&self, index: usize, result: &mut String) {
-        let mut buffer = Vec::with_capacity(64);
+        // Reuse the caller's allocation: take its bytes, refill them
+        // (get_in_place_impl clears first), and rebuild the String.
+        let mut buffer = std::mem::take(result).into_bytes();
         self.get_in_place_impl(index, &mut buffer);
-        result.clear();
         debug_assert!(std::str::from_utf8(&buffer).is_ok());
-        result.push_str(std::str::from_utf8(&buffer).unwrap());
+        *result = String::from_utf8(buffer).expect("rear-coded list stores valid UTF-8");
     }
 
     /// Returns the bytes of the string of given index.

--- a/src/dict/rear_coded_list.rs
+++ b/src/dict/rear_coded_list.rs
@@ -870,8 +870,13 @@ fn memcmp(string: &[u8], data: &[u8]) -> core::cmp::Ordering {
 
 impl<I: ?Sized, const SORTED: bool> RearCodedListBuilder<I, SORTED> {
     /// Creates a builder for a rear-coded list with a block size of `ratio`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ratio` is zero.
     #[must_use]
     pub fn new(ratio: usize) -> Self {
+        assert!(ratio > 0, "ratio must be positive");
         Self {
             data: Vec::with_capacity(1024),
             last_str: Vec::with_capacity(1024),

--- a/src/dict/rear_coded_list.rs
+++ b/src/dict/rear_coded_list.rs
@@ -1401,6 +1401,11 @@ mod epserde_impl {
     }
 
     /// Serializes to a stream a rear-coded list of strings directly from a lender of `AsRef<str>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lender fails during the second (serialization) pass;
+    /// such a mid-serialization failure is not recoverable.
     #[cfg(feature = "epserde")]
     pub fn serialize_str<
         T: ?Sized + Borrow<str>,
@@ -1418,6 +1423,11 @@ mod epserde_impl {
     }
 
     /// Serializes to a stream a rear-coded list of byte sequences directly from a lender of `AsRef<[u8]>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lender fails during the second (serialization) pass;
+    /// such a mid-serialization failure is not recoverable.
     #[cfg(feature = "epserde")]
     pub fn serialize_slice_u8<
         T: ?Sized + Borrow<[u8]>,
@@ -1436,6 +1446,11 @@ mod epserde_impl {
 
     /// Stores into a file a rear-coded list of strings built directly from a lender of
     /// `AsRef<str>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lender fails during the second (serialization) pass;
+    /// such a mid-serialization failure is not recoverable.
     #[cfg(feature = "epserde")]
     pub fn store_str<
         T: ?Sized + Borrow<str>,
@@ -1450,13 +1465,18 @@ mod epserde_impl {
         filename: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<usize> {
         let dst_file =
-            std::fs::File::create(filename.as_ref()).expect("Cannot create destination file");
+            std::fs::File::create(filename.as_ref())?;
         let mut buf_writer = std::io::BufWriter::new(dst_file);
         serialize_impl::<T, str, String, L, SORTED>(ratio, lender, &mut buf_writer)
     }
 
     /// Stores into a file a rear-coded list of strings built directly from a lender of
     /// `AsRef<[u8]>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lender fails during the second (serialization) pass;
+    /// such a mid-serialization failure is not recoverable.
     #[cfg(feature = "epserde")]
     pub fn store_slice_u8<
         T: ?Sized + Borrow<[u8]>,
@@ -1471,7 +1491,7 @@ mod epserde_impl {
         filename: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<usize> {
         let dst_file =
-            std::fs::File::create(filename.as_ref()).expect("Cannot create destination file");
+            std::fs::File::create(filename.as_ref())?;
         let mut buf_writer = std::io::BufWriter::new(dst_file);
         serialize_impl::<T, [u8], Vec<u8>, L, SORTED>(ratio, lender, &mut buf_writer)
     }

--- a/src/dict/rear_coded_list.rs
+++ b/src/dict/rear_coded_list.rs
@@ -353,9 +353,7 @@ impl<I: ?Sized, O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
     }
 }
 
-impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
-    RearCodedList<str, O, D, P, SORTED>
-{
+impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool> RearCodedList<str, O, D, P, SORTED> {
     /// Checks the structural invariants of this list.
     ///
     /// After deserializing from an untrusted or possibly stale source, call
@@ -1465,8 +1463,7 @@ mod epserde_impl {
         lender: L,
         filename: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<usize> {
-        let dst_file =
-            std::fs::File::create(filename.as_ref())?;
+        let dst_file = std::fs::File::create(filename.as_ref())?;
         let mut buf_writer = std::io::BufWriter::new(dst_file);
         serialize_impl::<T, str, String, L, SORTED>(ratio, lender, &mut buf_writer)
     }
@@ -1491,8 +1488,7 @@ mod epserde_impl {
         lender: L,
         filename: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<usize> {
-        let dst_file =
-            std::fs::File::create(filename.as_ref())?;
+        let dst_file = std::fs::File::create(filename.as_ref())?;
         let mut buf_writer = std::io::BufWriter::new(dst_file);
         serialize_impl::<T, [u8], Vec<u8>, L, SORTED>(ratio, lender, &mut buf_writer)
     }
@@ -1681,7 +1677,9 @@ mod tests {
         assert!(corrupt_list(2, 1, &[0x80], &[0]).validate().is_err());
         // Trailing bytes after the last element.
         assert!(
-            corrupt_list(2, 1, &[1, b'x', b'y'], &[0]).validate().is_err()
+            corrupt_list(2, 1, &[1, b'x', b'y'], &[0])
+                .validate()
+                .is_err()
         );
         // Empty list must validate.
         assert!(corrupt_list(2, 0, &[], &[]).validate().is_ok());

--- a/src/dict/rear_coded_list.rs
+++ b/src/dict/rear_coded_list.rs
@@ -285,6 +285,106 @@ impl<
     }
 }
 
+impl<I: ?Sized, O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
+    RearCodedList<I, O, D, P, SORTED>
+{
+    /// Shared validation logic; `check_utf8` additionally requires every
+    /// reconstructed element to be valid UTF-8 (used by the `str` variant).
+    fn validate_impl(&self, check_utf8: bool) -> anyhow::Result<()> {
+        anyhow::ensure!(self.ratio > 0, "ratio must be positive");
+        let data = self.data.as_ref();
+        let pointers = self.pointers.as_ref();
+        anyhow::ensure!(
+            pointers.len() == self.len.div_ceil(self.ratio),
+            "wrong number of block pointers: {} for {} elements with ratio {}",
+            pointers.len(),
+            self.len,
+            self.ratio
+        );
+        let mut buffer = Vec::new();
+        let mut rest: &[u8] = data;
+        for (block, &start) in pointers.iter().enumerate() {
+            let pos = data.len() - rest.len();
+            anyhow::ensure!(
+                start == pos,
+                "block {block} pointer {start} does not match the encoded stream position {pos}"
+            );
+            let in_block = Ord::min(self.ratio, self.len - block * self.ratio);
+            for k in 0..in_block {
+                let index = block * self.ratio + k;
+                let (suffix_len, r) = decode_int_checked(rest)
+                    .ok_or_else(|| anyhow::anyhow!("malformed length before element {index}"))?;
+                let r = if k == 0 {
+                    buffer.clear();
+                    r
+                } else {
+                    let (rear_len, r) = decode_int_checked(r).ok_or_else(|| {
+                        anyhow::anyhow!("malformed rear length before element {index}")
+                    })?;
+                    anyhow::ensure!(
+                        rear_len <= buffer.len(),
+                        "rear length {rear_len} of element {index} exceeds the previous element length {}",
+                        buffer.len()
+                    );
+                    buffer.truncate(buffer.len() - rear_len);
+                    r
+                };
+                anyhow::ensure!(
+                    suffix_len <= r.len(),
+                    "suffix length {suffix_len} of element {index} exceeds the remaining data ({})",
+                    r.len()
+                );
+                buffer.extend_from_slice(&r[..suffix_len]);
+                rest = &r[suffix_len..];
+                if check_utf8 {
+                    anyhow::ensure!(
+                        core::str::from_utf8(&buffer).is_ok(),
+                        "element {index} is not valid UTF-8"
+                    );
+                }
+            }
+        }
+        anyhow::ensure!(
+            rest.is_empty(),
+            "{} trailing bytes after the last encoded element",
+            rest.len()
+        );
+        Ok(())
+    }
+}
+
+impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
+    RearCodedList<str, O, D, P, SORTED>
+{
+    /// Checks the structural invariants of this list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: the accessors otherwise trust the encoded
+    /// stream (lengths, block pointers, UTF-8 validity) and can panic or
+    /// return fabricated data on malformed input.
+    ///
+    /// The check decodes the whole list once (`O(n)` in the encoded size).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        self.validate_impl(true)
+    }
+}
+
+impl<O, D: AsRef<[u8]>, P: AsRef<[usize]>, const SORTED: bool>
+    RearCodedList<[u8], O, D, P, SORTED>
+{
+    /// Checks the structural invariants of this list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: the accessors otherwise trust the encoded
+    /// stream (lengths, block pointers) and can panic or return fabricated
+    /// data on malformed input.
+    ///
+    /// The check decodes the whole list once (`O(n)` in the encoded size).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        self.validate_impl(false)
+    }
+}
+
 impl<
     I: PartialEq<O> + PartialEq + ?Sized,
     O: PartialEq<I> + PartialEq,
@@ -1194,6 +1294,30 @@ fn decode_int(mut data: &[u8]) -> (usize, &[u8]) {
     (value, data)
 }
 
+/// Bounds-checked VByte decoding for [`RearCodedList::validate`]: returns
+/// `None` on truncated input, overlong encodings, and value overflow.
+fn decode_int_checked(mut data: &[u8]) -> Option<(usize, &[u8])> {
+    // Each continuation byte contributes 7 bits, so more than this many
+    // bytes cannot encode a `usize`.
+    const MAX_BYTES: u32 = usize::BITS / 7 + 1;
+    let mut byte = *data.first()?;
+    data = &data[1..];
+    let mut value = usize::from(byte & 0x7F);
+    let mut bytes = 1;
+    while (byte >> 7) != 0 {
+        bytes += 1;
+        if bytes > MAX_BYTES {
+            return None;
+        }
+        value = value.checked_add(1)?;
+        byte = *data.first()?;
+        data = &data[1..];
+        // Multiplying by 128 is `<< 7` with overflow detection.
+        value = value.checked_mul(128)? | usize::from(byte & 0x7F);
+    }
+    Some((value, data))
+}
+
 // Structures for on-the-fly serialization with ε-serde
 #[cfg(feature = "epserde")]
 mod epserde_impl {
@@ -1490,6 +1614,86 @@ mod tests {
         assert_eq!(memcmp(b"abc", b"abc\0"), core::cmp::Ordering::Less);
         assert_eq!(memcmp(b"abc", b"ab\0"), core::cmp::Ordering::Greater);
         assert_eq!(memcmp(b"ab\0", b"abc"), core::cmp::Ordering::Less);
+    }
+
+    fn corrupt_list(
+        ratio: usize,
+        len: usize,
+        data: &[u8],
+        pointers: &[usize],
+    ) -> RearCodedList<[u8], Vec<u8>, Box<[u8]>, Box<[usize]>, true> {
+        RearCodedList {
+            ratio,
+            len,
+            data: data.into(),
+            pointers: pointers.into(),
+            _marker_i: PhantomData,
+            _marker_o: PhantomData,
+        }
+    }
+
+    #[test]
+    fn test_validate() {
+        let mut builder = RearCodedListBuilder::<[u8], true>::new(2);
+        for s in [b"aa".as_slice(), b"ab", b"ac", b"b"] {
+            builder.push(s);
+        }
+        let rcl = builder.build();
+        assert!(rcl.validate().is_ok());
+
+        // Zero ratio.
+        assert!(corrupt_list(0, 1, &[1, b'x'], &[0]).validate().is_err());
+        // Wrong number of block pointers.
+        assert!(corrupt_list(2, 1, &[1, b'x'], &[]).validate().is_err());
+        // Pointer not matching the stream position.
+        assert!(corrupt_list(2, 1, &[1, b'x'], &[1]).validate().is_err());
+        // Truncated suffix.
+        assert!(corrupt_list(2, 1, &[9, b'x'], &[0]).validate().is_err());
+        // Rear length exceeding the previous element: [3, "abc", 1, 4, "X"]
+        // asks to drop 4 bytes from a 3-byte element.
+        assert!(
+            corrupt_list(2, 2, &[3, b'a', b'b', b'c', 1, 4, b'X'], &[0])
+                .validate()
+                .is_err()
+        );
+        // Truncated VByte continuation.
+        assert!(corrupt_list(2, 1, &[0x80], &[0]).validate().is_err());
+        // Trailing bytes after the last element.
+        assert!(
+            corrupt_list(2, 1, &[1, b'x', b'y'], &[0]).validate().is_err()
+        );
+        // Empty list must validate.
+        assert!(corrupt_list(2, 0, &[], &[]).validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_utf8() {
+        let list = RearCodedList::<str, String, Box<[u8]>, Box<[usize]>, true> {
+            ratio: 2,
+            len: 1,
+            data: [1, 0xFF].as_slice().into(),
+            pointers: [0].as_slice().into(),
+            _marker_i: PhantomData,
+            _marker_o: PhantomData,
+        };
+        assert!(list.validate().is_err());
+    }
+
+    #[test]
+    fn test_decode_int_checked() {
+        // Round-trip against the encoder.
+        for value in [0usize, 1, 127, 128, 16383, 16384, usize::MAX] {
+            let mut data = Vec::new();
+            encode_int(value, &mut data);
+            let (decoded, rest) = decode_int_checked(&data).unwrap();
+            assert_eq!(decoded, value);
+            assert!(rest.is_empty());
+        }
+        // Truncated input.
+        assert_eq!(decode_int_checked(&[]), None);
+        assert_eq!(decode_int_checked(&[0x80]), None);
+        // Overlong encoding: more continuation bytes than a usize can hold.
+        assert_eq!(decode_int_checked(&[0xFF; 12]), None);
     }
 
     const UPPER_BOUND_1: usize = 128;

--- a/src/dict/vfilter.rs
+++ b/src/dict/vfilter.rs
@@ -31,6 +31,15 @@ use value_traits::slices::SliceByValue;
 /// For values of *b* that correspond to the size of an unsigned type, you can
 /// use a boxed slice as a backend.
 ///
+/// The stored and expected hashes are derived from a 64-bit remixed hash, so
+/// at most 64 bits are usable: `b` is capped at 64 (a boxed backend must be at
+/// most 64 bits wide). Moreover, with the default sharded fuse edges the
+/// verification hash is derived from the same 64-bit local signature that
+/// selects the edge, so two distinct keys colliding on it are
+/// indistinguishable: the false-positive rate has a floor of roughly *n*⁄2⁶⁴
+/// for *n* keys, independent of *b*. Use `FuseLge3FullSigs` to make this
+/// floor negligible.
+///
 /// Instances of this structure are immutable; they are built using [`try_new`]
 /// or one of its variants, and can be serialized with [ε-serde] or [`serde`].
 ///
@@ -411,6 +420,14 @@ mod build {
             for<'a> <Box<[W]> as SliceByValueMut>::ChunksMut<'a>: Send,
             for<'a> <<Box<[W]> as SliceByValueMut>::ChunksMut<'a> as Iterator>::Item: Send,
         {
+            // The verification hash is a 64-bit remixed hash, so a boxed
+            // filter wider than 64 bits would store fictional entropy in its
+            // high bits and advertise an unachievable false-positive rate.
+            anyhow::ensure!(
+                W::BITS <= 64,
+                "boxed VFilter words must be at most 64 bits (got {})",
+                W::BITS
+            );
             let filter_mask = W::MAX;
             let func = builder.try_build_filter(
                 keys,
@@ -522,6 +539,14 @@ mod build {
             K: Sync,
         {
             let n = keys.len();
+            // The verification hash is a 64-bit remixed hash, so a boxed
+            // filter wider than 64 bits would store fictional entropy in its
+            // high bits and advertise an unachievable false-positive rate.
+            anyhow::ensure!(
+                W::BITS <= 64,
+                "boxed VFilter words must be at most 64 bits (got {})",
+                W::BITS
+            );
             let filter_mask = W::MAX;
             let func = builder.expected_num_keys(n).try_par_populate_and_build(
                 keys,
@@ -692,8 +717,14 @@ mod build {
             for<'a> <<BitFieldVec<Box<[W]>> as SliceByValueMut>::ChunksMut<'a> as Iterator>::Item:
                 Send,
         {
-            assert!(filter_bits > 0);
-            assert!(filter_bits <= W::BITS as usize);
+            anyhow::ensure!(filter_bits > 0, "filter_bits must be positive");
+            // Filters store at most 64 hash bits: the remixed hash is 64-bit.
+            anyhow::ensure!(
+                filter_bits <= 64.min(W::BITS as usize),
+                "filter_bits ({filter_bits}) must be at most min(64, W::BITS) = {}",
+                64.min(W::BITS as usize)
+            );
+            // Sound: filter_bits <= 64 <= W::BITS, checked above.
             let filter_mask = W::MAX >> (W::BITS - filter_bits as u32);
             let func = builder.try_build_filter(
                 keys,
@@ -810,9 +841,15 @@ mod build {
         where
             K: Sync,
         {
-            assert!(filter_bits > 0);
-            assert!(filter_bits <= W::BITS as usize);
+            anyhow::ensure!(filter_bits > 0, "filter_bits must be positive");
+            // Filters store at most 64 hash bits: the remixed hash is 64-bit.
+            anyhow::ensure!(
+                filter_bits <= 64.min(W::BITS as usize),
+                "filter_bits ({filter_bits}) must be at most min(64, W::BITS) = {}",
+                64.min(W::BITS as usize)
+            );
             let n = keys.len();
+            // Sound: filter_bits <= 64 <= W::BITS, checked above.
             let filter_mask = W::MAX >> (W::BITS - filter_bits as u32);
             let func = builder.expected_num_keys(n).try_par_populate_and_build(
                 keys,
@@ -910,6 +947,31 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_hash_bits_cap() {
+        use crate::bits::BitFieldVec;
+        let keys: Vec<usize> = (0..10).collect();
+        // A boxed filter wider than 64 bits stores fictional entropy and is
+        // rejected.
+        assert!(<VFilter<usize, Box<[u128]>>>::try_par_new(&keys, no_logging![]).is_err());
+        // A bit-field filter with more than 64 bits is rejected (u64 word so
+        // the cap is the same on 32- and 64-bit targets).
+        assert!(
+            <VFilter<usize, BitFieldVec<Box<[u64]>>>>::try_par_new(&keys, 65, no_logging![])
+                .is_err()
+        );
+        // Zero bits is rejected.
+        assert!(
+            <VFilter<usize, BitFieldVec<Box<[u64]>>>>::try_par_new(&keys, 0, no_logging![])
+                .is_err()
+        );
+        // Exactly 64 bits is accepted.
+        assert!(
+            <VFilter<usize, BitFieldVec<Box<[u64]>>>>::try_par_new(&keys, 64, no_logging![])
+                .is_ok()
+        );
     }
 
     #[test]

--- a/src/dict/vfilter.rs
+++ b/src/dict/vfilter.rs
@@ -110,6 +110,19 @@ impl<K: ?Sized, D: SliceByValue, S, E> VFilter<K, D, S, E> {
     }
 }
 
+impl<K: ?Sized, D: SliceByValue + crate::bits::ValidateBacking, S: Sig, E: ShardEdge<S, 3>>
+    VFilter<K, D, S, E>
+{
+    /// Checks the invariants relied upon by [`contains`](Self::contains), for
+    /// use after deserializing from an untrusted source.
+    ///
+    /// Delegates to the underlying [`VFunc::validate`]; on `Ok`, `contains` is
+    /// memory-safe for any key.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        self.func.validate()
+    }
+}
+
 impl<K: ?Sized + ToSig<S>, D: SliceByValue<Value: Word + BinSafe>, S: Sig, E: ShardEdge<S, 3>>
     VFilter<K, D, S, E>
 where
@@ -125,6 +138,8 @@ where
     ///
     /// This is the signature-level entry point; most callers should use
     /// [`contains`] instead.
+    ///
+    /// See [`validate`](Self::validate) before querying deserialized instances.
     ///
     /// [`contains`]: Self::contains
     #[inline(always)]
@@ -166,6 +181,10 @@ where
     /// # #[cfg(not(feature = "rayon"))]
     /// # fn main() {}
     /// ```
+    ///
+    /// If this instance was deserialized from an untrusted source, call
+    /// [`validate`](Self::validate) first: it performs unchecked reads that
+    /// assume the builder-established layout invariants.
     ///
     /// [`contains_by_sig`]: Self::contains_by_sig
     #[inline]

--- a/src/func/codec.rs
+++ b/src/func/codec.rs
@@ -129,9 +129,9 @@ pub trait Decoder<W> {
 
 /// Degenerate codec that always emits length-0 codewords.
 ///
-/// Used when the value distribution has a single distinct value (or
-/// none): every key resolves to that value (or zero), so no bits need
-/// to be stored.
+/// Used when the value distribution is empty or entirely zero: every value
+/// decodes to zero, so no bits need to be stored. It cannot represent a
+/// nonzero value.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ZeroCodec;
 
@@ -153,7 +153,11 @@ impl<W: PrimitiveInteger + Hash> Codec<W> for ZeroCodec {
 
 impl<W: PrimitiveInteger> Coder<W> for ZeroCoder {
     type Decoder = ZeroDecoder;
-    fn encode(&self, _symbol: W) -> Option<usize> {
+    fn encode(&self, symbol: W) -> Option<usize> {
+        debug_assert!(
+            symbol == W::default(),
+            "ZeroCodec cannot encode a nonzero value"
+        );
         Some(0)
     }
     fn codeword_len(&self, _symbol: W) -> u32 {

--- a/src/func/codec.rs
+++ b/src/func/codec.rs
@@ -258,10 +258,12 @@ impl HuffmanConf {
         }
     }
 
-    /// Returns an unlimited Huffman codec: no cap on codeword lengths, no
-    /// entropy cut. All symbols get a codeword; no escape mechanism
-    /// is used. This can produce very long codewords for skewed
-    /// distributions.
+    /// Returns a Huffman codec with no decoding-table-length cap and no
+    /// entropy cut: no symbol is escaped for table-size or entropy reasons.
+    /// A single intrinsic cap still applies: codewords cannot exceed
+    /// `usize::BITS - 2` bits (the width of the decoder's read window), so on
+    /// a distribution skewed enough to produce a deeper code the deepest
+    /// symbols are escaped rather than assigned an unrepresentable codeword.
     pub const fn unlimited() -> Self {
         Self {
             max_decoding_table_len: usize::MAX,
@@ -775,6 +777,13 @@ fn build_huffman_coder<W: PrimitiveInteger + Hash>(
     let mut d = 1usize;
     let mut cutpoint = 0usize;
     while cutpoint < size {
+        // Codewords are assembled in a `usize` buffer and the decoder reads a
+        // full `usize` window, so a length beyond `usize::BITS - 2` cannot be
+        // represented. Truncate here and escape the remaining (deeper)
+        // symbols instead of overflowing the shift in canonical assignment.
+        if length[cutpoint] > usize::BITS - 2 {
+            break;
+        }
         if current_length != length[cutpoint] {
             d += 1;
             if d >= max_decoding_table_len {

--- a/src/func/codec.rs
+++ b/src/func/codec.rs
@@ -599,7 +599,9 @@ impl<W: PrimitiveInteger> HuffmanDecoder<W> {
                 }
             }
         }
-        unreachable!("decoder fell through all blocks")
+        // Out-of-window value (possible only for incomplete codes, e.g. a
+        // single-symbol table): mirror `decode_branchless` and report no match.
+        None
     }
 
     /// Branchless decode: counts blocks whose upper bound is `<=

--- a/src/func/codec.rs
+++ b/src/func/codec.rs
@@ -612,7 +612,14 @@ impl<W: PrimitiveInteger> HuffmanDecoder<W> {
             let lcp1 = unsafe { *self.last_codeword_plus_one.get_unchecked(curr) };
             idx += (lcp1 <= value) as usize;
         }
-        debug_assert!(idx < n);
+        // The derived block index can equal `n` for out-of-window (or empty-
+        // table) values; return None instead of an out-of-bounds unchecked read.
+        if idx >= n {
+            return None;
+        }
+        // SAFETY: `idx < n` is checked just above, so the `idx`-indexed reads of
+        // `last_codeword_plus_one` and `block_info` are in bounds; the
+        // `symbol` read is separately guarded by `sym_idx < nrs`.
         unsafe {
             let lcp1 = *self.last_codeword_plus_one.get_unchecked(idx);
             let bi = self.block_info.get_unchecked(idx);

--- a/src/func/codec.rs
+++ b/src/func/codec.rs
@@ -226,10 +226,11 @@ impl<W: PrimitiveInteger> Decoder<W> for ZeroDecoder {
 /// [`escaped_symbols_len`]: Decoder::escaped_symbols_len
 #[derive(Debug, Clone, Copy)]
 pub struct HuffmanConf {
-    /// Hard cap on the number of distinct codeword lengths kept in
-    /// the decoding table. Symbols whose codeword length exceeds
-    /// this limit are encoded via the escape codeword followed by
-    /// a literal. Default: 20.
+    /// Hard cap on the number of blocks in the canonical decoding table,
+    /// *including* the escape block when escaping occurs: at most
+    /// `max_decoding_table_len - 1` distinct codeword lengths are kept, and
+    /// symbols beyond the cut are encoded via the escape codeword followed
+    /// by a literal. Default: 20.
     pub max_decoding_table_len: usize,
     /// Cumulative-entropy fraction threshold: the table is cut once
     /// the cumulative bit length of the codewords kept exceeds this
@@ -272,8 +273,10 @@ impl HuffmanConf {
     ///
     /// # Arguments
     ///
-    /// * `max_decoding_table_len` - caps the number of distinct
-    ///   codeword lengths in the canonical decoding table.
+    /// * `max_decoding_table_len` - caps the number of blocks in the
+    ///   canonical decoding table, including the escape block when escaping
+    ///   occurs (i.e., at most `max_decoding_table_len - 1` distinct
+    ///   codeword lengths are kept).
     ///
     /// * `entropy_threshold` - the cumulative-entropy fraction
     ///   beyond which infrequent symbols are diverted to the escape

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -198,12 +198,8 @@ impl<
     }
 }
 
-impl<
-    K: ?Sized,
-    D: Backend<Word: Word> + AsRef<[D::Word]>,
-    S,
-    E: ShardEdge<S, 3>,
-> CompVFunc<K, D, S, E>
+impl<K: ?Sized, D: Backend<Word: Word> + AsRef<[D::Word]>, S, E: ShardEdge<S, 3>>
+    CompVFunc<K, D, S, E>
 {
     /// Checks the invariants relied upon by [`get`](Self::get), for use after
     /// deserializing from an untrusted source.

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -1392,12 +1392,10 @@ impl<K: ?Sized, W: Word, S, E> TryIntoUnaligned for CompVFunc<K, BitVec<Box<[W]>
     fn try_into_unaligned(self) -> Result<Self::Unaligned, UnalignedConversionError> {
         let esym = Decoder::escaped_symbols_len(&self.decoder) as usize;
         if esym > 0 && !test_unaligned_any_pos!(W, esym) {
-            return Err(UnalignedConversionError(format!(
-                "escaped-symbol bit width {esym} does not satisfy the constraints \
-                 for arbitrary-position unaligned reads on {} (must be <= {})",
-                core::any::type_name::<W>(),
-                W::BITS as usize - 7
-            )));
+            return Err(UnalignedConversionError::InvalidPosition {
+                bit_width: esym,
+                word_bits: W::BITS,
+            });
         }
         Ok(CompVFunc {
             shard_edge: self.shard_edge,

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -1492,13 +1492,11 @@ mod codec_bound_tests {
     use super::*;
 
     #[test]
-    fn test_build_coder_rejects_overlong_codeword() {
+    fn test_build_coder_escapes_overlong_codeword() {
         // Fibonacci frequencies over `usize::BITS` u128 symbols force a
-        // maximally unbalanced Huffman tree (depth usize::BITS - 1), whose max
-        // codeword length exceeds usize::BITS - 2 even though it fits W::BITS - 7
-        // for W = u128. The preflight must reject it, since the decoder
-        // constructor asserts `w <= usize::BITS - 2`. Using usize::BITS symbols
-        // keeps the Fibonacci counts within usize on 32-bit as well.
+        // maximally unbalanced Huffman tree (depth usize::BITS - 1). The codec
+        // now escapes the deepest symbols so the kept codewords stay within
+        // usize::BITS - 2, and the CompVFunc preflight accepts the coder.
         let mut frequencies: HashMap<u128, usize> = HashMap::new();
         let (mut prev, mut cur) = (1usize, 1usize);
         for symbol in 0u128..u128::from(usize::BITS) {
@@ -1507,10 +1505,12 @@ mod codec_bound_tests {
             prev = cur;
             cur = next;
         }
-        let result = build_coder_from_frequencies(HuffmanConf::unlimited(), &frequencies);
+        let coder = build_coder_from_frequencies(HuffmanConf::unlimited(), &frequencies)
+            .expect("deep symbols are escaped, so the coder builds within the limit");
+        assert!(coder.max_codeword_len() <= usize::BITS - 2);
         assert!(
-            result.is_err(),
-            "expected an error for a codeword longer than usize::BITS - 2"
+            coder.escaped_symbols_len() > 0,
+            "the deepest symbols must be escaped"
         );
     }
 }

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -293,7 +293,10 @@ impl<K: ?Sized, D: Backend<Word: Word>, S, E> CompVFunc<K, D, S, E> {
 // VBuilder<BitVec<Box<[W]>>, S, E> configured with the usual VBuilder knobs
 // (offline, check-dups, low-mem, threads, eps, seed). The only
 // CompVFunc-specific configuration is the Huffman codec used for values; the
-// default is unlimited-length Huffman.
+// default is HuffmanConf::new() (decoding-table cap 20, entropy threshold
+// 0.9), which escapes rare symbols; use HuffmanConf::unlimited() to drop the
+// table-size and entropy cuts (only the intrinsic codeword-length cap then
+// escapes symbols).
 //
 // Both build- and query-side edge generation go through
 // ShardEdge::local_edge(shard_edge.local_sig(sig)), which provides fuse-graph

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -185,9 +185,9 @@ impl<
         // The literal sits at the low end [0..esym_len).
         // SAFETY: the bit vector is padded.
         unsafe {
-            self.data.get_value_unchecked(v0, esym_len)
-                ^ self.data.get_value_unchecked(v1, esym_len)
-                ^ self.data.get_value_unchecked(v2, esym_len)
+            self.data.get_bits_unchecked(v0, esym_len)
+                ^ self.data.get_bits_unchecked(v1, esym_len)
+                ^ self.data.get_bits_unchecked(v2, esym_len)
         }
     }
 }

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -147,6 +147,10 @@ impl<
 {
     /// Returns the value associated with `key`, or an arbitrary value
     /// if `key` is not in the original key set.
+    ///
+    /// If this instance was deserialized from an untrusted source, call
+    /// [`validate`](Self::validate) first: this method performs unchecked reads
+    /// that assume the builder-established layout invariants.
     #[inline(always)]
     pub fn get(&self, key: impl Borrow<K>) -> D::Word {
         self.get_by_sig(K::to_sig(key.borrow(), self.seed))
@@ -154,6 +158,8 @@ impl<
 
     /// Returns the value associated with the given signature, or an
     /// arbitrary value if no key has that signature.
+    ///
+    /// See [`validate`](Self::validate) before querying deserialized instances.
     #[inline(always)]
     pub fn get_by_sig(&self, sig: S) -> D::Word {
         // Here we compute manually the edge vertices. We cannot use
@@ -189,6 +195,60 @@ impl<
                 ^ self.data.get_bits_unchecked(v1, esym_len)
                 ^ self.data.get_bits_unchecked(v2, esym_len)
         }
+    }
+}
+
+impl<
+    K: ?Sized,
+    D: Backend<Word: Word> + AsRef<[D::Word]>,
+    S,
+    E: ShardEdge<S, 3>,
+> CompVFunc<K, D, S, E>
+{
+    /// Checks the invariants relied upon by [`get`](Self::get), for use after
+    /// deserializing from an untrusted source.
+    ///
+    /// Verifies that the shard/edge parameters are well formed and that the
+    /// backing storage is large enough that the unchecked reads performed by
+    /// `get` cannot go out of bounds. On `Ok`, `get` is memory-safe for any
+    /// key; the values returned for corrupt-but-in-bounds data are arbitrary.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        use num_primitive::PrimitiveInteger;
+        self.shard_edge.validate()?;
+        let shard_bits = self.shard_edge.shard_high_bits();
+        anyhow::ensure!(
+            shard_bits < usize::BITS,
+            "shard_high_bits {shard_bits} is too large"
+        );
+        let num_shards = 1usize << shard_bits;
+        let word_bits = D::Word::BITS as usize; // BITS <= 128, lossless
+        let esym_len = self.decoder.escaped_symbols_len() as usize; // u32, lossless
+        anyhow::ensure!(
+            esym_len <= word_bits,
+            "escaped symbols length {esym_len} exceeds the word size"
+        );
+        let num_vertices = self.shard_edge.num_vertices();
+        anyhow::ensure!(num_vertices > 0, "the shard edge has no vertices");
+        // Highest bit position `get` can touch: the unaligned word read at
+        // `shard_offset + v + esym_len` for the last vertex of the last
+        // shard ends at most `word_bits` bits later.
+        let last_read_end = (num_shards - 1)
+            .checked_mul(self.shard_size)
+            .and_then(|x| x.checked_add(num_vertices - 1))
+            .and_then(|x| x.checked_add(esym_len))
+            .and_then(|x| x.checked_add(word_bits))
+            .ok_or_else(|| anyhow::anyhow!("shard layout overflows usize"))?;
+        let backing_bits = self
+            .data
+            .as_ref()
+            .len()
+            .checked_mul(word_bits)
+            .ok_or_else(|| anyhow::anyhow!("backing size in bits overflows usize"))?;
+        anyhow::ensure!(
+            last_read_end <= backing_bits,
+            "backing holds {backing_bits} bits but reads may touch bit {last_read_end}"
+        );
+        Ok(())
     }
 }
 
@@ -1452,5 +1512,37 @@ mod codec_bound_tests {
             result.is_err(),
             "expected an error for a codeword longer than usize::BITS - 2"
         );
+    }
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+    use crate::utils::FromCloneableIntoIterator;
+    use crate::utils::lenders::FromSlice;
+    use dsi_progress_logger::no_logging;
+
+    fn build_small() -> CompVFunc<usize> {
+        let n = 100usize;
+        let values: Vec<usize> = (0..n).map(|i| i % 5).collect();
+        CompVFunc::<usize>::try_new(
+            FromCloneableIntoIterator::from(0..n),
+            FromSlice::new(&values),
+            no_logging![],
+        )
+        .expect("build")
+    }
+
+    #[test]
+    fn test_validate_accepts_built_function() {
+        assert!(build_small().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_truncated_backing() {
+        let mut func = build_small();
+        // Far smaller than any edge read the shard edge can produce.
+        func.data = BitVec::<Box<[usize]>>::new_padded(64);
+        assert!(func.validate().is_err());
     }
 }

--- a/src/func/comp_vfunc.rs
+++ b/src/func/comp_vfunc.rs
@@ -400,10 +400,10 @@ fn build_coder_from_frequencies<W: Word + Hash>(
     // The codeword is read via get_unaligned_unchecked, which reads a
     // full W and shifts right by up to 7 bits.
     let w = coder.max_codeword_len();
-    let max = W::BITS - 7;
+    let max = (W::BITS - 7).min(usize::BITS - 2);
     if w > max {
         return Err(anyhow!(
-            "max codeword length {w} exceeds the unaligned-read limit of {max}: try again after limiting the Huffman codec"
+            "max codeword length {w} exceeds the readable limit of {max} (min of W::BITS-7 and usize::BITS-2): try again after limiting the Huffman codec"
         ));
     }
     Ok(coder)
@@ -521,20 +521,36 @@ where
             core::any::type_name::<S>()
         ));
         // Padding for multi-edge expansion
-        let raw_stride = num_vertices_per_shard + w as usize;
+        let raw_stride = num_vertices_per_shard
+            .checked_add(w as usize)
+            .ok_or_else(|| anyhow!("shard stride overflows usize"))?;
+        let force_index_peeler = raw_stride >= PackedEdge::MAX_VERTICES as usize;
+        if force_index_peeler && raw_stride as u64 > u32::MAX as u64 + 1 {
+            // The index peeler stores vertex indices as u32, so `base + off`
+            // below would truncate for a shard with more than u32::MAX + 1
+            // vertices (reachable only for ShardEdge families whose Vertex is
+            // wider than u32). Reject before rounding and allocating.
+            return Err(anyhow!(
+                "shard has too many vertices ({raw_stride}) for the u32 index peeler"
+            ));
+        }
         // `par_solve` chunks the data via `BitVec::try_chunks_mut`,
         // which requires `chunk_size` to be a multiple of `W::BITS`.
-        let stride = raw_stride.next_multiple_of(W::BITS as usize);
+        let word_bits = W::BITS as usize;
+        let stride = raw_stride
+            .div_ceil(word_bits)
+            .checked_mul(word_bits)
+            .ok_or_else(|| anyhow!("shard stride padding overflows usize"))?;
+        let total_bits = num_shards
+            .checked_mul(stride)
+            .ok_or_else(|| anyhow!("data size overflow"))?;
 
         pl.info(format_args!(
             "c: {}; overhead (vertices/edges): {:+.3}%",
             c,
-            100.0 * ((stride * num_shards) as f64 / (total_edges as f64) - 1.),
+            100.0 * (total_bits as f64 / (total_edges as f64) - 1.),
         ));
         let padding = stride - num_vertices_per_shard;
-        let total_bits = num_shards
-            .checked_mul(stride)
-            .ok_or_else(|| anyhow!("data size overflow"))?;
 
         let mut data = BitVec::<Box<[W]>>::new_padded(total_bits);
 
@@ -557,7 +573,6 @@ where
         // None of the peelers use a Gaussian elimination fallback as in
         // VBuilder: on any unpeeled remainder the shard is retried with a new
         // seed.
-        let force_index_peeler = raw_stride >= PackedEdge::MAX_VERTICES as usize;
         let use_low_mem = vb.low_mem == Some(true)
             || (vb.low_mem.is_none() && vb.num_threads > 3 && num_shards > 2);
         let solve_shard = |this: &VBuilder<BitVec<Box<[W]>>, S, E>,
@@ -1411,5 +1426,33 @@ impl<K: ?Sized, W: Word, S, E> From<CompVFunc<K, BitVecU<Box<[W]>>, S, E>>
             decoder: u.decoder,
             _marker: PhantomData,
         }
+    }
+}
+
+#[cfg(test)]
+mod codec_bound_tests {
+    use super::*;
+
+    #[test]
+    fn test_build_coder_rejects_overlong_codeword() {
+        // Fibonacci frequencies over `usize::BITS` u128 symbols force a
+        // maximally unbalanced Huffman tree (depth usize::BITS - 1), whose max
+        // codeword length exceeds usize::BITS - 2 even though it fits W::BITS - 7
+        // for W = u128. The preflight must reject it, since the decoder
+        // constructor asserts `w <= usize::BITS - 2`. Using usize::BITS symbols
+        // keeps the Fibonacci counts within usize on 32-bit as well.
+        let mut frequencies: HashMap<u128, usize> = HashMap::new();
+        let (mut prev, mut cur) = (1usize, 1usize);
+        for symbol in 0u128..u128::from(usize::BITS) {
+            frequencies.insert(symbol, cur);
+            let next = prev + cur;
+            prev = cur;
+            cur = next;
+        }
+        let result = build_coder_from_frequencies(HuffmanConf::unlimited(), &frequencies);
+        assert!(
+            result.is_err(),
+            "expected an error for a codeword longer than usize::BITS - 2"
+        );
     }
 }

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -171,11 +171,15 @@ where
         let packed = self.lcp_freq_len_offset.get_by_sig(sig);
         let offset = packed & ((1 << self.log2_bucket_size) - 1);
         let frequent_lcp = packed >> self.log2_bucket_size;
+        // Absent keys yield an arbitrary packed value; clamp the decoded LCP
+        // length to the key width so IntBitPrefix::new cannot overflow. Present
+        // keys always have lcp_bit_len <= K::BITS, so this is a no-op for them.
         let lcp_bit_len = if frequent_lcp != self.escape {
             self.remap[frequent_lcp]
         } else {
             self.lcp_infreq_len.get_by_sig(sig)
-        };
+        }
+        .min(K::BITS as usize);
         let prefix = IntBitPrefix::new(key ^ K::MIN, lcp_bit_len);
         let bucket = self.lcp_to_bucket.get(prefix);
         (bucket << self.log2_bucket_size) + offset
@@ -186,7 +190,7 @@ where
 mod build {
     use super::*;
     use crate::func::VBuilder;
-    use crate::func::lcp_mmphf::{lcp_bits, lcp_bits_nul, log2_bucket_size};
+    use crate::func::lcp_mmphf::{checked_full_key_bits, lcp_bits, lcp_bits_nul, log2_bucket_size};
     use crate::func::vfunc2::{HybridMap, find_optimal_r};
     use anyhow::{Result, bail};
     use dsi_progress_logger::ProgressLog;
@@ -1260,6 +1264,11 @@ mod build {
                                     );
                                 }
 
+                                // Validate the key length up front so both the
+                                // bucket-start computation and lcp_bits_nul's
+                                // internal `len * 8` cannot overflow on 32-bit.
+                                let full_key_bits = checked_full_key_bits(key_bytes)?;
+
                                 let offset = idx & bucket_mask;
 
                                 // Start of a new bucket — flush the previous one.
@@ -1281,9 +1290,9 @@ mod build {
                                         push(SigVal { sig, val: packed })?;
                                     }
                                     buf.clear();
-                                    curr_lcp_bits = (key_bytes.len() + 1) * 8;
+                                    curr_lcp_bits = full_key_bits;
                                 } else if offset == 0 {
-                                    curr_lcp_bits = (key_bytes.len() + 1) * 8;
+                                    curr_lcp_bits = full_key_bits;
                                 } else {
                                     curr_lcp_bits = curr_lcp_bits
                                         .min(lcp_bits_nul::<true>(key_bytes, &prev_key));
@@ -1672,6 +1681,11 @@ mod build {
                     );
                 }
 
+                // Validate the key length up front so both the bucket-start
+                // computation and lcp_bits_nul's internal `len * 8` cannot
+                // overflow on 32-bit targets.
+                let full_key_bits = checked_full_key_bits(key_bytes)?;
+
                 let offset = i & bucket_mask;
 
                 if offset == 0 {
@@ -1686,7 +1700,7 @@ mod build {
                         lcp_counts.add(lcp, bsize);
                     }
                     bucket_first_keys.push(key_bytes.to_vec());
-                    curr_lcp_bits = (key_bytes.len() + 1) * 8;
+                    curr_lcp_bits = full_key_bits;
                 } else {
                     curr_lcp_bits = curr_lcp_bits.min(lcp_bits_nul::<true>(key_bytes, &prev_key));
                 }
@@ -2127,7 +2141,7 @@ where
 
         let key_bytes: &[u8] = key.as_ref();
         let lcp2b_seed = self.lcp_to_bucket.seed;
-        let lcp2b_sig: S1 = if lcp_bit_len <= key_bytes.len() * 8 {
+        let lcp2b_sig: S1 = if lcp_bit_len <= key_bytes.len().saturating_mul(8) {
             bit_prefix_sig(key_bytes, lcp_bit_len, lcp2b_seed)
         } else {
             // Rare: LCP extends into the virtual NUL (at most 8 extra bits).

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -1264,9 +1264,13 @@ mod build {
                                 // Start of a new bucket — flush the previous one.
                                 if offset == 0 && idx > 0 {
                                     let lcp = curr_lcp_bits;
-                                    state.lcp_bit_lens.push(
-                                        LcpLen::try_from(lcp).expect("LCP length exceeds u32"),
-                                    );
+                                    state.lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(
+                                        |_| {
+                                            anyhow::anyhow!(
+                                                "LCP length of {lcp} bits exceeds u32::MAX"
+                                            )
+                                        },
+                                    )?);
                                     state.max_lcp = state.max_lcp.max(lcp);
                                     let bsize = buf.len();
                                     state.lcp_counts.add(lcp, bsize);
@@ -1298,9 +1302,9 @@ mod build {
                             // Flush the last (possibly partial) bucket.
                             if !buf.is_empty() {
                                 let lcp = curr_lcp_bits;
-                                state
-                                    .lcp_bit_lens
-                                    .push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
+                                state.lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
+                                    anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
+                                })?);
                                 state.max_lcp = state.max_lcp.max(lcp);
                                 let bsize = buf.len();
                                 state.lcp_counts.add(lcp, bsize);
@@ -1672,7 +1676,9 @@ mod build {
                     // First key of a new bucket.
                     if i > 0 {
                         let lcp = curr_lcp_bits;
-                        lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
+                        lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
+                            anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
+                        })?);
                         max_lcp = max_lcp.max(lcp);
                         let bsize = bucket_size; // previous bucket was full
                         lcp_counts.add(lcp, bsize);
@@ -1690,7 +1696,9 @@ mod build {
             // Flush the last (possibly partial) bucket.
             {
                 let lcp = curr_lcp_bits;
-                lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
+                lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
+                    anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
+                })?);
                 max_lcp = max_lcp.max(lcp);
                 let bsize = n - (num_buckets - 1) * bucket_size;
                 lcp_counts.add(lcp, bsize);

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -682,6 +682,7 @@ mod build {
                     )
                 };
 
+                builder.enable_dup_check_on_unsolvable(&result, pl);
                 if let Some(r) = rs.handle_solve_result(result, pl)? {
                     pl.info(format_args!(
                         "Construction completed in {:.3} seconds ({} keys, {:.3} ns/key)",
@@ -1505,6 +1506,7 @@ mod build {
                     )
                 };
 
+                builder.enable_dup_check_on_unsolvable(&result, pl);
                 if let Some(r) = rs.handle_solve_result(result, pl)? {
                     pl.info(format_args!(
                         "Construction completed in {:.3} seconds ({} keys, {:.3} ns/key)",

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -505,7 +505,7 @@ mod build {
                                 buf.clear();
                             }
 
-                            assert_eq!(idx, n, "Expected {n} keys but got {idx}");
+                            anyhow::ensure!(idx == n, "Expected {n} keys but got {idx}");
                             assert_eq!(state.lcp_bit_lens.len(), num_buckets);
 
                             Ok(max_value)
@@ -1316,7 +1316,7 @@ mod build {
                                 buf.clear();
                             }
 
-                            assert_eq!(idx, n, "Expected {n} keys but got {idx}");
+                            anyhow::ensure!(idx == n, "Expected {n} keys but got {idx}");
                             assert_eq!(state.lcp_bit_lens.len(), num_buckets);
 
                             Ok(max_value)

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -1248,69 +1248,33 @@ mod build {
                     state.lcp_counts = HybridMap::new(None, 0);
                     state.max_lcp = 0;
 
-                    let mut populate =
-                        |seed: u64,
-                         push: &mut dyn FnMut(SigVal<S0, u64>) -> anyhow::Result<()>,
-                         pl: &mut P,
-                         state: &mut State| {
-                            while let Some(key) = keys.next()? {
-                                pl.light_update();
-                                let key_bytes: &[u8] = key.as_ref();
+                    let mut populate = |seed: u64,
+                                        push: &mut dyn FnMut(
+                        SigVal<S0, u64>,
+                    )
+                        -> anyhow::Result<()>,
+                                        pl: &mut P,
+                                        state: &mut State| {
+                        while let Some(key) = keys.next()? {
+                            pl.light_update();
+                            let key_bytes: &[u8] = key.as_ref();
 
-                                if idx > 0 && key_bytes <= prev_key.as_slice() {
-                                    bail!(
-                                        "Keys are not in strictly increasing lexicographic order \
+                            if idx > 0 && key_bytes <= prev_key.as_slice() {
+                                bail!(
+                                    "Keys are not in strictly increasing lexicographic order \
                                  at position {idx}"
-                                    );
-                                }
-
-                                // Validate the key length up front so both the
-                                // bucket-start computation and lcp_bits_nul's
-                                // internal `len * 8` cannot overflow on 32-bit.
-                                let full_key_bits = checked_full_key_bits(key_bytes)?;
-
-                                let offset = idx & bucket_mask;
-
-                                // Start of a new bucket — flush the previous one.
-                                if offset == 0 && idx > 0 {
-                                    let lcp = curr_lcp_bits;
-                                    state.lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(
-                                        |_| {
-                                            anyhow::anyhow!(
-                                                "LCP length of {lcp} bits exceeds u32::MAX"
-                                            )
-                                        },
-                                    )?);
-                                    state.max_lcp = state.max_lcp.max(lcp);
-                                    let bsize = buf.len();
-                                    state.lcp_counts.add(lcp, bsize);
-                                    for (i, &sig) in buf.iter().enumerate() {
-                                        let packed = ((lcp as u64) << log2_bs) | i as u64;
-                                        max_value = max_value.max(packed);
-                                        push(SigVal { sig, val: packed })?;
-                                    }
-                                    buf.clear();
-                                    curr_lcp_bits = full_key_bits;
-                                } else if offset == 0 {
-                                    curr_lcp_bits = full_key_bits;
-                                } else {
-                                    curr_lcp_bits = curr_lcp_bits
-                                        .min(lcp_bits_nul::<true>(key_bytes, &prev_key));
-                                }
-
-                                if offset == 0 {
-                                    state.bucket_first_keys.push(key_bytes.to_vec());
-                                }
-
-                                let sig = K::to_sig(key.borrow(), seed);
-                                buf.push(sig);
-                                prev_key.clear();
-                                prev_key.extend_from_slice(key_bytes);
-                                idx += 1;
+                                );
                             }
 
-                            // Flush the last (possibly partial) bucket.
-                            if !buf.is_empty() {
+                            // Validate the key length up front so both the
+                            // bucket-start computation and lcp_bits_nul's
+                            // internal `len * 8` cannot overflow on 32-bit.
+                            let full_key_bits = checked_full_key_bits(key_bytes)?;
+
+                            let offset = idx & bucket_mask;
+
+                            // Start of a new bucket — flush the previous one.
+                            if offset == 0 && idx > 0 {
                                 let lcp = curr_lcp_bits;
                                 state.lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
                                     anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
@@ -1324,13 +1288,47 @@ mod build {
                                     push(SigVal { sig, val: packed })?;
                                 }
                                 buf.clear();
+                                curr_lcp_bits = full_key_bits;
+                            } else if offset == 0 {
+                                curr_lcp_bits = full_key_bits;
+                            } else {
+                                curr_lcp_bits =
+                                    curr_lcp_bits.min(lcp_bits_nul::<true>(key_bytes, &prev_key));
                             }
 
-                            anyhow::ensure!(idx == n, "Expected {n} keys but got {idx}");
-                            assert_eq!(state.lcp_bit_lens.len(), num_buckets);
+                            if offset == 0 {
+                                state.bucket_first_keys.push(key_bytes.to_vec());
+                            }
 
-                            Ok(max_value)
-                        };
+                            let sig = K::to_sig(key.borrow(), seed);
+                            buf.push(sig);
+                            prev_key.clear();
+                            prev_key.extend_from_slice(key_bytes);
+                            idx += 1;
+                        }
+
+                        // Flush the last (possibly partial) bucket.
+                        if !buf.is_empty() {
+                            let lcp = curr_lcp_bits;
+                            state.lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
+                                anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
+                            })?);
+                            state.max_lcp = state.max_lcp.max(lcp);
+                            let bsize = buf.len();
+                            state.lcp_counts.add(lcp, bsize);
+                            for (i, &sig) in buf.iter().enumerate() {
+                                let packed = ((lcp as u64) << log2_bs) | i as u64;
+                                max_value = max_value.max(packed);
+                                push(SigVal { sig, val: packed })?;
+                            }
+                            buf.clear();
+                        }
+
+                        anyhow::ensure!(idx == n, "Expected {n} keys but got {idx}");
+                        assert_eq!(state.lcp_bit_lens.len(), num_buckets);
+
+                        Ok(max_value)
+                    };
 
                     builder.try_solve_once(
                         seed,
@@ -1712,9 +1710,11 @@ mod build {
             // Flush the last (possibly partial) bucket.
             {
                 let lcp = curr_lcp_bits;
-                lcp_bit_lens.push(LcpLen::try_from(lcp).map_err(|_| {
-                    anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
-                })?);
+                lcp_bit_lens.push(
+                    LcpLen::try_from(lcp).map_err(|_| {
+                        anyhow::anyhow!("LCP length of {lcp} bits exceeds u32::MAX")
+                    })?,
+                );
                 max_lcp = max_lcp.max(lcp);
                 let bsize = n - (num_buckets - 1) * bucket_size;
                 lcp_counts.add(lcp, bsize);

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -207,6 +207,29 @@ mod build {
         ));
     }
 
+    /// Builds the `remap` table and its inverse map from the value frequencies.
+    ///
+    /// `remap` is padded to `escape_usize` (not just `num_freq`) so that the
+    /// safe `get` can index it with any first-VFunc output in `[0, escape)`,
+    /// including the arbitrary outputs produced by absent keys. The padding
+    /// entries are zero and are excluded from `inv_map`, which maps only the
+    /// `num_freq` frequent values to their indices (missing values resolve to
+    /// the `escape_usize` sentinel).
+    fn build_remap_and_inv(
+        sorted_vals: &[usize],
+        escape_usize: usize,
+        num_freq: usize,
+        max_lcp: usize,
+    ) -> (Box<[usize]>, HybridMap<usize, usize>) {
+        let mut remap: Box<[usize]> = vec![0usize; escape_usize].into_boxed_slice();
+        remap[..num_freq].copy_from_slice(&sorted_vals[..num_freq]);
+        let mut inv_map: HybridMap<usize, usize> = HybridMap::new(Some(max_lcp), escape_usize);
+        for (i, &val) in remap[..num_freq].iter().enumerate() {
+            inv_map.insert(val, i);
+        }
+        (remap, inv_map)
+    }
+
     #[cfg(target_pointer_width = "64")]
     type LcpLen = u32;
     #[cfg(not(target_pointer_width = "64"))]
@@ -516,13 +539,12 @@ mod build {
                             let escape_usize = (1usize << best_r).wrapping_sub(1);
                             let num_freq = escape_usize.min(m);
 
-                            let remap: Box<[usize]> =
-                                sorted_vals[..num_freq].to_vec().into_boxed_slice();
-                            let mut inv_map: HybridMap<usize, usize> =
-                                HybridMap::new(Some(state.max_lcp), escape_usize);
-                            for (i, &val) in remap.iter().enumerate() {
-                                inv_map.insert(val, i);
-                            }
+                            let (remap, inv_map) = build_remap_and_inv(
+                                &sorted_vals,
+                                escape_usize,
+                                num_freq,
+                                state.max_lcp,
+                            );
 
                             let num_infreq = n_keys
                                 - sorted_vals[..num_freq]
@@ -856,11 +878,8 @@ mod build {
             let escape_usize = (1usize << best_r).wrapping_sub(1);
             let num_freq = escape_usize.min(m);
 
-            let remap: Box<[usize]> = sorted_vals[..num_freq].to_vec().into_boxed_slice();
-            let mut inv_map: HybridMap<usize, usize> = HybridMap::new(Some(max_lcp), escape_usize);
-            for (i, &val) in remap.iter().enumerate() {
-                inv_map.insert(val, i);
-            }
+            let (remap, inv_map) =
+                build_remap_and_inv(&sorted_vals, escape_usize, num_freq, max_lcp);
 
             let num_infreq = n - sorted_vals[..num_freq]
                 .iter()
@@ -1323,13 +1342,12 @@ mod build {
                             let escape_usize = (1usize << best_r).wrapping_sub(1);
                             let num_freq = escape_usize.min(m);
 
-                            let remap: Box<[usize]> =
-                                sorted_vals[..num_freq].to_vec().into_boxed_slice();
-                            let mut inv_map: HybridMap<usize, usize> =
-                                HybridMap::new(Some(state.max_lcp), escape_usize);
-                            for (i, &val) in remap.iter().enumerate() {
-                                inv_map.insert(val, i);
-                            }
+                            let (remap, inv_map) = build_remap_and_inv(
+                                &sorted_vals,
+                                escape_usize,
+                                num_freq,
+                                state.max_lcp,
+                            );
 
                             let num_infreq = n_keys
                                 - sorted_vals[..num_freq]
@@ -1688,11 +1706,8 @@ mod build {
             let escape_usize = (1usize << best_r).wrapping_sub(1);
             let num_freq = escape_usize.min(m);
 
-            let remap: Box<[usize]> = sorted_vals[..num_freq].to_vec().into_boxed_slice();
-            let mut inv_map: HybridMap<usize, usize> = HybridMap::new(Some(max_lcp), escape_usize);
-            for (i, &val) in remap.iter().enumerate() {
-                inv_map.insert(val, i);
-            }
+            let (remap, inv_map) =
+                build_remap_and_inv(&sorted_vals, escape_usize, num_freq, max_lcp);
 
             let num_infreq = n - sorted_vals[..num_freq]
                 .iter()
@@ -1849,6 +1864,33 @@ mod build {
                     total_start.elapsed().as_nanos() as f64 / n as f64
                 ));
             })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// `build_remap_and_inv` must pad `remap` to the full escape range so
+        /// safe `get` cannot index out of bounds when the first VFunc returns a
+        /// value in `[num_freq, escape)` (reachable for absent keys). The
+        /// padding must be zero and excluded from `inv_map`.
+        #[test]
+        fn remap_padded_to_escape() {
+            let sorted_vals = [10usize, 20, 30, 40, 50];
+            let escape_usize = 7;
+            let num_freq = 5;
+            let (remap, inv_map) = build_remap_and_inv(&sorted_vals, escape_usize, num_freq, 100);
+            assert_eq!(remap.len(), escape_usize);
+            assert_eq!(&remap[..num_freq], &sorted_vals);
+            assert_eq!(&remap[num_freq..], &[0usize, 0]);
+            for (i, &v) in sorted_vals.iter().enumerate() {
+                assert_eq!(inv_map.get(v), i);
+            }
+            // A non-frequent value resolves to the escape sentinel, and the
+            // zero padding must not have been inserted into `inv_map`.
+            assert_eq!(inv_map.get(15), escape_usize);
+            assert_eq!(inv_map.get(0), escape_usize);
         }
     }
 } // mod build

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -230,10 +230,9 @@ mod build {
         (remap, inv_map)
     }
 
-    #[cfg(target_pointer_width = "64")]
+    // Always u32 so that LCP bit-lengths above 65535 do not silently wrap on
+    // 32-bit targets (where this alias was previously u16).
     type LcpLen = u32;
-    #[cfg(not(target_pointer_width = "64"))]
-    type LcpLen = u16;
 
     impl<
         K: PrimitiveInteger + ToSig<S0> + std::fmt::Debug + Send + Sync + Copy + Ord,
@@ -459,7 +458,9 @@ mod build {
                                 // Start of a new bucket — flush the previous one.
                                 if offset == 0 && idx > 0 {
                                     let lcp = curr_lcp_bits;
-                                    state.lcp_bit_lens.push(lcp as LcpLen);
+                                    state.lcp_bit_lens.push(
+                                        LcpLen::try_from(lcp).expect("LCP length exceeds u32"),
+                                    );
                                     state.max_lcp = state.max_lcp.max(lcp);
                                     let bsize = buf.len();
                                     state.lcp_counts.add(lcp, bsize);
@@ -490,7 +491,9 @@ mod build {
                             // Flush the last (possibly partial) bucket.
                             if !buf.is_empty() {
                                 let lcp = curr_lcp_bits;
-                                state.lcp_bit_lens.push(lcp as LcpLen);
+                                state
+                                    .lcp_bit_lens
+                                    .push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                                 state.max_lcp = state.max_lcp.max(lcp);
                                 let bsize = buf.len();
                                 state.lcp_counts.add(lcp, bsize);
@@ -838,7 +841,7 @@ mod build {
                     // First key of a new bucket.
                     if i > 0 {
                         let lcp = curr_lcp_bits;
-                        lcp_bit_lens.push(lcp as LcpLen);
+                        lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                         max_lcp = max_lcp.max(lcp);
                         let bsize = bucket_size; // previous bucket was full
                         lcp_counts.add(lcp, bsize);
@@ -855,7 +858,7 @@ mod build {
             // Flush the last (possibly partial) bucket.
             {
                 let lcp = curr_lcp_bits;
-                lcp_bit_lens.push(lcp as LcpLen);
+                lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                 max_lcp = max_lcp.max(lcp);
                 let bsize = n - (num_buckets - 1) * bucket_size;
                 lcp_counts.add(lcp, bsize);
@@ -1261,7 +1264,9 @@ mod build {
                                 // Start of a new bucket — flush the previous one.
                                 if offset == 0 && idx > 0 {
                                     let lcp = curr_lcp_bits;
-                                    state.lcp_bit_lens.push(lcp as LcpLen);
+                                    state.lcp_bit_lens.push(
+                                        LcpLen::try_from(lcp).expect("LCP length exceeds u32"),
+                                    );
                                     state.max_lcp = state.max_lcp.max(lcp);
                                     let bsize = buf.len();
                                     state.lcp_counts.add(lcp, bsize);
@@ -1293,7 +1298,9 @@ mod build {
                             // Flush the last (possibly partial) bucket.
                             if !buf.is_empty() {
                                 let lcp = curr_lcp_bits;
-                                state.lcp_bit_lens.push(lcp as LcpLen);
+                                state
+                                    .lcp_bit_lens
+                                    .push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                                 state.max_lcp = state.max_lcp.max(lcp);
                                 let bsize = buf.len();
                                 state.lcp_counts.add(lcp, bsize);
@@ -1665,7 +1672,7 @@ mod build {
                     // First key of a new bucket.
                     if i > 0 {
                         let lcp = curr_lcp_bits;
-                        lcp_bit_lens.push(lcp as LcpLen);
+                        lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                         max_lcp = max_lcp.max(lcp);
                         let bsize = bucket_size; // previous bucket was full
                         lcp_counts.add(lcp, bsize);
@@ -1683,7 +1690,7 @@ mod build {
             // Flush the last (possibly partial) bucket.
             {
                 let lcp = curr_lcp_bits;
-                lcp_bit_lens.push(lcp as LcpLen);
+                lcp_bit_lens.push(LcpLen::try_from(lcp).expect("LCP length exceeds u32"));
                 max_lcp = max_lcp.max(lcp);
                 let bsize = n - (num_buckets - 1) * bucket_size;
                 lcp_counts.add(lcp, bsize);
@@ -1891,6 +1898,17 @@ mod build {
             // zero padding must not have been inserted into `inv_map`.
             assert_eq!(inv_map.get(15), escape_usize);
             assert_eq!(inv_map.get(0), escape_usize);
+        }
+
+        /// `LcpLen` must hold LCP bit-lengths above 65535 on every target (it
+        /// was previously u16 on 32-bit, silently wrapping long common
+        /// prefixes).
+        #[test]
+        fn lcp_len_holds_large_prefixes() {
+            assert!(
+                u64::from(LcpLen::MAX) >= 65536,
+                "LcpLen must hold LCP lengths above 65535 bits"
+            );
         }
     }
 } // mod build

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -395,7 +395,7 @@ mod build {
                 max_lcp: 0,
             };
 
-            let mut rs = builder.retry_state(pl);
+            let mut rs = builder.retry_state(pl)?;
 
             loop {
                 let seed = rs.next_seed();
@@ -1203,7 +1203,7 @@ mod build {
                 max_lcp: 0,
             };
 
-            let mut rs = builder.retry_state(pl);
+            let mut rs = builder.retry_state(pl)?;
 
             loop {
                 let seed = rs.next_seed();

--- a/src/func/lcp2_mmphf.rs
+++ b/src/func/lcp2_mmphf.rs
@@ -762,7 +762,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// let func = Lcp2MmphfInt::<u64>::try_par_new_with_builder(
         ///     &keys,
-        ///     VBuilder::default().offline(true),
+        ///     VBuilder::default(),
         ///     no_logging![],
         /// )?.try_into_unaligned()?;
         ///
@@ -1584,7 +1584,7 @@ mod build {
         /// let keys = vec!["a", "b", "c", "d", "e"];
         /// let func = <Lcp2MmphfStr>::try_par_new_with_builder(
         ///     &keys,
-        ///     VBuilder::default().offline(true),
+        ///     VBuilder::default(),
         ///     no_logging![],
         /// )?.try_into_unaligned()?;
         ///

--- a/src/func/lcp_mmphf.rs
+++ b/src/func/lcp_mmphf.rs
@@ -490,7 +490,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// let func = LcpMmphfInt::<u64>::try_par_new_with_builder(
         ///     &keys,
-        ///     VBuilder::default().offline(true),
+        ///     VBuilder::default(),
         ///     no_logging![],
         /// )?.try_into_unaligned()?;
         ///
@@ -1022,7 +1022,7 @@ mod build {
         /// let keys = vec!["a", "b", "c", "d", "e"];
         /// let func = <LcpMmphfStr>::try_par_new_with_builder(
         ///     &keys,
-        ///     VBuilder::default().offline(true),
+        ///     VBuilder::default(),
         ///     no_logging![],
         /// )?.try_into_unaligned()?;
         ///

--- a/src/func/lcp_mmphf.rs
+++ b/src/func/lcp_mmphf.rs
@@ -110,6 +110,8 @@ impl<K: PrimitiveInteger> IntBitPrefix<K> {
 ///
 /// On 32-bit targets an enormous single key could otherwise wrap the `usize`
 /// multiplication and produce a bogus LCP length.
+// Only the rayon-gated `build` modules of this file and `lcp2_mmphf` call this.
+#[cfg(feature = "rayon")]
 #[inline]
 pub(crate) fn checked_full_key_bits(bytes: &[u8]) -> anyhow::Result<usize> {
     bytes

--- a/src/func/lcp_mmphf.rs
+++ b/src/func/lcp_mmphf.rs
@@ -105,6 +105,20 @@ impl<K: PrimitiveInteger> IntBitPrefix<K> {
     }
 }
 
+/// Returns the bit length of a byte key including its virtual trailing NUL,
+/// i.e. `(bytes.len() + 1) * 8`, with overflow checking.
+///
+/// On 32-bit targets an enormous single key could otherwise wrap the `usize`
+/// multiplication and produce a bogus LCP length.
+#[inline]
+pub(crate) fn checked_full_key_bits(bytes: &[u8]) -> anyhow::Result<usize> {
+    bytes
+        .len()
+        .checked_add(1)
+        .and_then(|n| n.checked_mul(8))
+        .ok_or_else(|| anyhow::anyhow!("byte-key bit length overflows usize"))
+}
+
 /// Packs significant bits and bit_len into a contiguous stack buffer
 /// for one-shot xxh3 hashing. Returns the number of bytes written.
 /// Buffer must be at least `size_of::<K>() + size_of::<usize>()` bytes.
@@ -865,6 +879,11 @@ mod build {
                     );
                 }
 
+                // Validate the key length up front so both this bucket-start
+                // computation and lcp_bits_nul's internal `len * 8` cannot
+                // overflow on 32-bit targets.
+                let full_key_bits = checked_full_key_bits(key_bytes)?;
+
                 let offset = i & bucket_mask;
 
                 if offset == 0 {
@@ -874,7 +893,7 @@ mod build {
                     }
                     bucket_first_keys.push(key_bytes.to_vec());
                     // Initialize to full key bit-length (including virtual NUL).
-                    curr_lcp_bits = (key_bytes.len() + 1) * 8;
+                    curr_lcp_bits = full_key_bits;
                 } else {
                     // Subsequent key: minimize LCP.
                     curr_lcp_bits = curr_lcp_bits.min(lcp_bits_nul::<true>(key_bytes, &prev_key));
@@ -1097,6 +1116,11 @@ mod build {
                     );
                 }
 
+                // Validate the key length up front so both this bucket-start
+                // computation and lcp_bits_nul's internal `len * 8` cannot
+                // overflow on 32-bit targets.
+                let full_key_bits = checked_full_key_bits(key_bytes)?;
+
                 let offset = i & bucket_mask;
 
                 if offset == 0 {
@@ -1105,7 +1129,7 @@ mod build {
                         lcp_bit_lens.push(curr_lcp_bits);
                     }
                     bucket_first_keys.push(key_bytes.to_vec());
-                    curr_lcp_bits = (key_bytes.len() + 1) * 8;
+                    curr_lcp_bits = full_key_bits;
                 } else {
                     curr_lcp_bits = curr_lcp_bits.min(lcp_bits_nul::<true>(key_bytes, &prev_key));
                 }
@@ -1281,7 +1305,10 @@ where
     #[inline]
     pub fn get(&self, key: K) -> usize {
         let packed = self.lcp_len_offset.get(key);
-        let lcp_bit_len = packed >> self.log2_bucket_size;
+        // Absent keys yield an arbitrary packed value; clamp the decoded LCP
+        // length to the key width so IntBitPrefix::new cannot overflow. Present
+        // keys always have lcp_bit_len <= K::BITS, so this is a no-op for them.
+        let lcp_bit_len = (packed >> self.log2_bucket_size).min(K::BITS as usize);
         let offset = packed & ((1 << self.log2_bucket_size) - 1);
         // XOR with K::MIN maps signed numeric order to bit-lexicographic
         // order by flipping the sign bit; for unsigned types K::MIN is 0,
@@ -1544,7 +1571,7 @@ where
         // without allocating a BitPrefix.
         let key_bytes: &[u8] = key.as_ref();
         let seed = self.lcp_to_bucket.seed;
-        let sig: S1 = if lcp_bit_len <= key_bytes.len() * 8 {
+        let sig: S1 = if lcp_bit_len <= key_bytes.len().saturating_mul(8) {
             bit_prefix_sig(key_bytes, lcp_bit_len, seed)
         } else {
             // Rare: LCP extends into the virtual NUL (at most 8 extra bits).

--- a/src/func/lcp_mmphf.rs
+++ b/src/func/lcp_mmphf.rs
@@ -373,7 +373,7 @@ mod build {
                 i += 1;
             }
 
-            assert_eq!(i, n, "Expected {n} keys but got {i}");
+            anyhow::ensure!(i == n, "Expected {n} keys but got {i}");
             lcp_bit_lens.push(curr_lcp_bits);
             assert_eq!(lcp_bit_lens.len(), num_buckets);
 
@@ -885,7 +885,7 @@ mod build {
                 i += 1;
             }
 
-            assert_eq!(i, n, "Expected {n} keys but got {i}");
+            anyhow::ensure!(i == n, "Expected {n} keys but got {i}");
             lcp_bit_lens.push(curr_lcp_bits);
             assert_eq!(lcp_bit_lens.len(), num_buckets);
 

--- a/src/func/mod.rs
+++ b/src/func/mod.rs
@@ -29,10 +29,12 @@
 //!   [`LcpMmphfInt`]/[`LcpMmphf`] that use a [`VFunc2`]-like technique to reduce
 //!   space usage, at the cost of slightly slower queries.
 //!
-//! - [`SignedFunc`] wraps any of the above with per-key verification hashes,
-//!   returning `None` for keys outside the original set. Use `Box<[W]>` for
-//!   full-width hashes or [`BitFieldVec`] for sub-word-width hashes. Use
-//!   concrete types like `SignedFunc<LcpMmphfStr, Box<[u64]>>`.
+//! - [`SignedFunc`] wraps a [`VFunc`], [`LcpMmphfInt`]/[`LcpMmphf`], or
+//!   [`Lcp2MmphfInt`]/[`Lcp2Mmphf`] (but not [`VFunc2`]) with per-key
+//!   verification hashes, returning `None` for keys outside the original set.
+//!   Use `Box<[W]>` for full-width hashes or [`BitFieldVec`] for
+//!   sub-word-width hashes. Use concrete types like
+//!   `SignedFunc<LcpMmphfStr, Box<[u64]>>`.
 //!
 //! Most structures implement the [`TryIntoUnaligned`] trait, allowing them
 //! to be converted into (usually faster) structures using unaligned access.

--- a/src/func/shard_edge.rs
+++ b/src/func/shard_edge.rs
@@ -225,6 +225,19 @@ pub trait ShardEdge<S, const K: usize>: Default + Display + Clone + Copy + Send 
     /// Returns the number of high bits used for sharding.
     fn shard_high_bits(&self) -> u32;
 
+    /// Validates the sharding/edge parameters of this instance, for use
+    /// after deserializing from an untrusted source.
+    ///
+    /// On `Ok`, the parameter accessors ([`shard_high_bits`],
+    /// [`num_vertices`]) and edge computations do not panic or overflow.
+    /// The default implementation accepts any instance.
+    ///
+    /// [`shard_high_bits`]: ShardEdge::shard_high_bits
+    /// [`num_vertices`]: ShardEdge::num_vertices
+    fn validate(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Returns the number of sorting keys to be used for count sorting
     /// signatures before processing.
     ///
@@ -506,6 +519,25 @@ mod fuse {
         type LocalSig = [u64; 1];
         type Vertex = u32;
 
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.shard_bits_shift <= 63,
+                "shard_bits_shift {} exceeds 63",
+                self.shard_bits_shift
+            );
+            anyhow::ensure!(
+                self.log2_seg_size <= 32,
+                "log2_seg_size {} exceeds 32",
+                self.log2_seg_size
+            );
+            // The shift is in range: log2_seg_size <= 32 was checked above.
+            anyhow::ensure!(
+                (u128::from(self.l) + 2) << self.log2_seg_size <= 1u128 << 32,
+                "(l + 2) << log2_seg_size exceeds u32::MAX + 1"
+            );
+            Ok(())
+        }
+
         fn set_up_shards(&mut self, n: usize, eps: f64) {
             self.shard_bits_shift = 63
                 - if n <= Self::MAX_LIN_SIZE {
@@ -758,6 +790,20 @@ mod fuse {
         type LocalSig = [u64; 1];
         type Vertex = u32;
 
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.log2_seg_size <= 32,
+                "log2_seg_size {} exceeds 32",
+                self.log2_seg_size
+            );
+            // The shift is in range: log2_seg_size <= 32 was checked above.
+            anyhow::ensure!(
+                (u128::from(self.l) + 2) << self.log2_seg_size <= 1u128 << 32,
+                "(l + 2) << log2_seg_size exceeds u32::MAX + 1"
+            );
+            Ok(())
+        }
+
         fn set_up_shards(&mut self, _n: usize, _eps: f64) {}
 
         fn set_up_graphs(&mut self, n: usize, _max_shard: usize) -> (f64, bool) {
@@ -828,6 +874,22 @@ mod fuse {
         type SortSigVal<V: BinSafe> = SigVal<[u64; 1], V>;
         type LocalSig = [u64; 2];
         type Vertex = u64;
+
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.log2_seg_size <= 63,
+                "log2_seg_size {} exceeds 63",
+                self.log2_seg_size
+            );
+            // The shift is in range: log2_seg_size <= 63 was checked above.
+            // Vertices are computed in usize; `as u128` is a lossless
+            // widening (usize is at most 64 bits).
+            anyhow::ensure!(
+                (u128::from(self.l) + 2) << self.log2_seg_size <= usize::MAX as u128 + 1,
+                "(l + 2) << log2_seg_size exceeds usize::MAX + 1"
+            );
+            Ok(())
+        }
 
         fn set_up_shards(&mut self, _n: usize, _eps: f64) {}
 
@@ -1010,6 +1072,25 @@ mod fuse {
         type LocalSig = [u64; 1];
         type Vertex = u32;
 
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.shard_bits_shift <= 63,
+                "shard_bits_shift {} exceeds 63",
+                self.shard_bits_shift
+            );
+            anyhow::ensure!(
+                self.log2_seg_size <= 32,
+                "log2_seg_size {} exceeds 32",
+                self.log2_seg_size
+            );
+            // The shift is in range: log2_seg_size <= 32 was checked above.
+            anyhow::ensure!(
+                (u128::from(self.l) + 2) << self.log2_seg_size <= 1u128 << 32,
+                "(l + 2) << log2_seg_size exceeds u32::MAX + 1"
+            );
+            Ok(())
+        }
+
         fn set_up_shards(&mut self, n: usize, eps: f64) {
             self.shard_bits_shift = 63
                 - if n <= Self::MIN_SHARD {
@@ -1174,6 +1255,10 @@ mod fuse {
         type LocalSig = [u64; 2];
         type Vertex = u32;
 
+        fn validate(&self) -> anyhow::Result<()> {
+            self.0.validate()
+        }
+
         fn set_up_shards(&mut self, n: usize, eps: f64) {
             self.0.set_up_shards(n, eps);
         }
@@ -1241,6 +1326,47 @@ mod fuse {
             )
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_validate_rejects_corrupt_fuse_lge_3_shards() {
+            let good = FuseLge3Shards::default();
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&good).is_ok());
+            let bad = FuseLge3Shards {
+                shard_bits_shift: 64,
+                log2_seg_size: 0,
+                l: 0,
+            };
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&bad).is_err());
+            let bad = FuseLge3Shards {
+                shard_bits_shift: 63,
+                log2_seg_size: 60,
+                l: 0,
+            };
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&bad).is_err());
+        }
+
+        #[test]
+        fn test_validate_rejects_corrupt_fuse_3_shards() {
+            let good = Fuse3Shards::default();
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&good).is_ok());
+            let bad = Fuse3Shards {
+                shard_bits_shift: 64,
+                log2_seg_size: 0,
+                l: 0,
+            };
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&bad).is_err());
+            let bad = Fuse3Shards {
+                shard_bits_shift: 63,
+                log2_seg_size: 60,
+                l: 0,
+            };
+            assert!(ShardEdge::<[u64; 2], 3>::validate(&bad).is_err());
+        }
+    }
 }
 
 pub use fuse::*;
@@ -1275,6 +1401,15 @@ mod mwhc {
         type SortSigVal<V: BinSafe> = SigVal<[u64; 2], V>;
         type LocalSig = [u64; 2];
         type Vertex = u64;
+
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.seg_size.checked_mul(3).is_some(),
+                "seg_size {} * 3 overflows usize",
+                self.seg_size
+            );
+            Ok(())
+        }
 
         fn set_up_shards(&mut self, _n: usize, _eps: f64) {}
 
@@ -1425,6 +1560,20 @@ mod mwhc {
         type SortSigVal<V: BinSafe> = SigVal<[u64; 2], V>;
         type LocalSig = [u64; 2];
         type Vertex = u32;
+
+        fn validate(&self) -> anyhow::Result<()> {
+            anyhow::ensure!(
+                self.shard_bits_shift <= 63,
+                "shard_bits_shift {} exceeds 63",
+                self.shard_bits_shift
+            );
+            anyhow::ensure!(
+                self.seg_size.checked_mul(3).is_some(),
+                "seg_size {} * 3 overflows usize",
+                self.seg_size
+            );
+            Ok(())
+        }
 
         fn set_up_shards(&mut self, n: usize, eps: f64) {
             self.shard_bits_shift =

--- a/src/func/signed.rs
+++ b/src/func/signed.rs
@@ -244,6 +244,12 @@ impl<K: ?Sized, D: SliceByValue, S: Sig, E: ShardEdge<S, 3>> SignableFunc for VF
 /// storage: for `Box<[W]>` it is 2<sup>−`W::BITS`</sup>; for [`BitFieldVec`]
 /// it is 2<sup>−`hash_width`</sup>.
 ///
+/// The verification hashes are derived from a 64-bit remixed hash. With the
+/// default sharded fuse edges that hash is derived from the same 64-bit local
+/// signature that selects the edge, so distinct keys colliding on it are
+/// indistinguishable: the false-positive probability has a floor of roughly
+/// *n*⁄2⁶⁴ for *n* keys. Use `FuseLge3FullSigs` to make this floor negligible.
+///
 /// Instances of this structure are immutable; they are built using [`try_new`]
 /// or one of its variants, and can be serialized using [ε-serde] or [`serde`].
 ///

--- a/src/func/signed.rs
+++ b/src/func/signed.rs
@@ -1361,7 +1361,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// let func =
         ///     <SignedFunc<LcpMmphfInt<u64>, Box<[u16]>>>::try_par_new_with_builder(
-        ///         &keys, VBuilder::default().offline(true), no_logging![],
+        ///         &keys, VBuilder::default(), no_logging![],
         ///     )?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
@@ -1557,7 +1557,7 @@ mod build {
         /// let keys = vec!["a", "b", "c", "d", "e"];
         /// let func =
         ///     <SignedFunc<LcpMmphfStr, Box<[u64]>>>::try_par_new_with_builder(
-        ///         &keys, VBuilder::default().offline(true), no_logging![],
+        ///         &keys, VBuilder::default(), no_logging![],
         ///     )?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
@@ -1755,7 +1755,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// let func =
         ///     <SignedFunc<Lcp2MmphfInt<u64>, Box<[u16]>>>::try_par_new_with_builder(
-        ///         &keys, VBuilder::default().offline(true), no_logging![],
+        ///         &keys, VBuilder::default(), no_logging![],
         ///     )?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
@@ -1953,7 +1953,7 @@ mod build {
         /// let keys = vec!["a", "b", "c", "d", "e"];
         /// let func =
         ///     <SignedFunc<Lcp2MmphfStr, Box<[u64]>>>::try_par_new_with_builder(
-        ///         &keys, VBuilder::default().offline(true), no_logging![],
+        ///         &keys, VBuilder::default(), no_logging![],
         ///     )?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
@@ -2163,7 +2163,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// type BSFunc = SignedFunc<LcpMmphfInt<u64>, BitFieldVec<Box<[usize]>>>;
         /// let func =
-        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default().offline(true), no_logging![])?.try_into_unaligned()?;
+        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default(), no_logging![])?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
         ///     assert_eq!(func.get(key), Some(i));
@@ -2377,7 +2377,7 @@ mod build {
         /// let keys = vec!["alpha", "beta", "delta", "gamma"];
         /// type BSFunc = SignedFunc<LcpMmphfStr, BitFieldVec<Box<[usize]>>>;
         /// let func =
-        ///     BSFunc::try_par_new_with_builder(&keys, 12, VBuilder::default().offline(true), no_logging![])?.try_into_unaligned()?;
+        ///     BSFunc::try_par_new_with_builder(&keys, 12, VBuilder::default(), no_logging![])?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
         ///     assert_eq!(func.get(key), Some(i));
@@ -2590,7 +2590,7 @@ mod build {
         /// let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
         /// type BSFunc = SignedFunc<Lcp2MmphfInt<u64>, BitFieldVec<Box<[usize]>>>;
         /// let func =
-        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default().offline(true), no_logging![])?.try_into_unaligned()?;
+        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default(), no_logging![])?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
         ///     assert_eq!(func.get(key), Some(i));
@@ -2798,7 +2798,7 @@ mod build {
         /// let keys = vec!["a", "b", "c", "d", "e"];
         /// type BSFunc = SignedFunc<Lcp2MmphfStr, BitFieldVec<Box<[usize]>>>;
         /// let func =
-        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default().offline(true), no_logging![])?.try_into_unaligned()?;
+        ///     BSFunc::try_par_new_with_builder(&keys, 8, VBuilder::default(), no_logging![])?.try_into_unaligned()?;
         ///
         /// for (i, &key) in keys.iter().enumerate() {
         ///     assert_eq!(func.get(key), Some(i));

--- a/src/func/signed.rs
+++ b/src/func/signed.rs
@@ -1068,8 +1068,13 @@ mod build {
         where
             u64: PrimitiveNumberAs<H>,
         {
-            assert!(hash_width > 0);
-            assert!(hash_width <= H::BITS as usize);
+            anyhow::ensure!(hash_width > 0, "hash_width must be positive");
+            // Verification hashes come from a 64-bit remixed hash.
+            anyhow::ensure!(
+                hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be at most min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
 
             let (func, mut store, _) = builder.try_build_func_and_store(
                 keys,
@@ -1206,8 +1211,13 @@ mod build {
             K: Sync,
             u64: PrimitiveNumberAs<H>,
         {
-            assert!(hash_width > 0);
-            assert!(hash_width <= H::BITS as usize);
+            anyhow::ensure!(hash_width > 0, "hash_width must be positive");
+            // Verification hashes come from a 64-bit remixed hash.
+            anyhow::ensure!(
+                hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be at most min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let values: Vec<usize> = (0..keys.len()).collect();
             let func = <VFunc<K, BitFieldVec<Box<[usize]>>, S, E>>::try_par_new_with_builder(
                 keys, &values, builder, pl,
@@ -2104,7 +2114,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let (func, keys) = LcpMmphfInt::try_new_inner(keys, n, builder, pl)?;
             let mut keys = keys.rewind()?;
             pl.push_log_target(" ▸ hashes");
@@ -2205,7 +2220,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let func = LcpMmphfInt::try_par_new_inner(keys, builder, pl)?;
             pl.push_log_target(" ▸ hashes");
             let hashes = fill_bit_hashes_from_slice::<K, K, H, S0, E0>(
@@ -2314,7 +2334,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let (func, keys) = LcpMmphf::try_new_inner(keys, n, builder, pl)?;
             let mut keys = keys.rewind()?;
             pl.push_log_target(" ▸ hashes");
@@ -2423,7 +2448,12 @@ mod build {
         where
             K: Sync,
         {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let func = LcpMmphf::try_par_new_inner(keys, builder, pl)?;
             pl.push_log_target(" ▸ hashes");
             let hashes = fill_bit_hashes_from_slice::<B, K, H, S0, E0>(
@@ -2535,7 +2565,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let (func, keys) = Lcp2MmphfInt::try_new_inner(keys, n, builder, pl)?;
             let mut keys = keys.rewind()?;
             pl.push_log_target(" ▸ hashes");
@@ -2632,7 +2667,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let func = Lcp2MmphfInt::try_par_new_inner(keys, builder, pl)?;
             pl.push_log_target(" ▸ hashes");
             let hashes = fill_bit_hashes_from_slice::<K, K, H, S0, E0>(
@@ -2740,7 +2780,12 @@ mod build {
             builder: VBuilder<BitFieldVec<Box<[usize]>>, S0, E0>,
             pl: &mut (impl ProgressLog + Clone + Send + Sync),
         ) -> Result<Self> {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let (func, keys) = Lcp2Mmphf::try_new_inner(keys, n, builder, pl)?;
             let mut keys = keys.rewind()?;
             pl.push_log_target(" ▸ hashes");
@@ -2843,7 +2888,12 @@ mod build {
         where
             K: Sync,
         {
-            assert!(hash_width > 0 && hash_width <= H::BITS as usize);
+            anyhow::ensure!(
+                // Verification hashes come from a 64-bit remixed hash.
+                hash_width > 0 && hash_width <= 64.min(H::BITS as usize),
+                "hash_width ({hash_width}) must be in 1..=min(64, H::BITS) = {}",
+                64.min(H::BITS as usize)
+            );
             let func = Lcp2Mmphf::try_par_new_inner(keys, builder, pl)?;
             pl.push_log_target(" ▸ hashes");
             let hashes = fill_bit_hashes_from_slice::<B, K, H, S0, E0>(

--- a/src/func/signed.rs
+++ b/src/func/signed.rs
@@ -313,6 +313,23 @@ impl<F: SignableFunc, H: SliceByValue<Value: PrimitiveNumber> + TruncateHash<H::
     pub fn is_empty(&self) -> bool {
         self.func.is_empty()
     }
+
+    /// Checks that the hash storage matches the function.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, or
+    /// after building with [`from_parts`](Self::from_parts), call this method
+    /// before use: a hash array shorter than the function silently turns
+    /// present keys into `None` (a false negative), and the inner function's
+    /// own invariants should be checked separately with its `validate` method.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.hashes.len() == self.func.len(),
+            "the hash storage has {} entries but the function has {} keys",
+            self.hashes.len(),
+            self.func.len()
+        );
+        Ok(())
+    }
 }
 
 // ── VFunc `get` ──────────────────────────────────────────────────
@@ -2866,5 +2883,23 @@ where
             func: f.func.into(),
             hashes: f.hashes.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::func::VFunc;
+    use crate::func::shard_edge::FuseLge3Shards;
+
+    #[test]
+    fn test_validate_length_mismatch() {
+        type F = VFunc<usize, BitFieldVec<Box<[usize]>>, [u64; 2], FuseLge3Shards>;
+        // Empty function with empty hashes: consistent.
+        let good = SignedFunc::from_parts(F::empty(), Box::<[usize]>::from([]));
+        assert!(good.validate().is_ok());
+        // Empty function with a nonempty hash array: mismatch.
+        let bad = SignedFunc::from_parts(F::empty(), Box::<[usize]>::from([0usize]));
+        assert!(bad.validate().is_err());
     }
 }

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -418,6 +418,7 @@ pub(crate) struct RetryState {
     prng: SmallRng,
     dup_count: u32,
     local_dup_count: u32,
+    max_shard_too_big: u32,
     unsolvable_count: u32,
 }
 
@@ -464,6 +465,15 @@ impl RetryState {
                         Ok(None)
                     }
                     SolveError::MaxShardTooBig => {
+                        self.max_shard_too_big += 1;
+                        if self.max_shard_too_big >= 100 {
+                            pl.error(format_args!(
+                                "The maximum shard was too big on more than 100 attempts"
+                            ));
+                            return Err(anyhow::anyhow!(
+                                "the maximum shard was too big on more than 100 attempts; try a larger eps"
+                            ));
+                        }
                         pl.warn(format_args!(
                             "The maximum shard is too big, trying again with a different seed..."
                         ));
@@ -682,7 +692,7 @@ impl<
         for<'a> ShardDataIter<'a, D>: Send,
         for<'a> <ShardDataIter<'a, D> as Iterator>::Item: Send,
     {
-        let mut rs = self.retry_state(pl);
+        let mut rs = self.retry_state(pl)?;
         let total_start = Instant::now();
 
         loop {
@@ -758,18 +768,24 @@ impl<
     /// [`try_populate_and_build`] performs at the start.
     ///
     /// [`try_populate_and_build`]: Self::try_populate_and_build
-    pub(crate) fn retry_state(&mut self, pl: &mut impl ProgressLog) -> RetryState {
+    pub(crate) fn retry_state(&mut self, pl: &mut impl ProgressLog) -> anyhow::Result<RetryState> {
+        anyhow::ensure!(
+            self.eps.is_finite() && self.eps >= 0.0,
+            "eps must be finite and non-negative, got {}",
+            self.eps
+        );
         self.init_shards_and_seed();
         pl.info(format_args!(
             "Using a store with 2^{} buckets",
             self.log2_buckets
         ));
-        RetryState {
+        Ok(RetryState {
             prng: SmallRng::seed_from_u64(self.seed),
             dup_count: 0,
             local_dup_count: 0,
+            max_shard_too_big: 0,
             unsolvable_count: 0,
-        }
+        })
     }
 
     /// Populates a shard store from keys and values, then calls a build
@@ -827,7 +843,7 @@ impl<
     where
         SigVal<S, V>: RadixKey,
     {
-        let mut rs = self.retry_state(pl);
+        let mut rs = self.retry_state(pl)?;
         let total_start = Instant::now();
 
         loop {
@@ -916,7 +932,7 @@ impl<
             !self.offline,
             "offline mode is not supported by the parallel builder; use the sequential constructor (try_new_with_builder)"
         );
-        let mut rs = self.retry_state(pl);
+        let mut rs = self.retry_state(pl)?;
         let n = keys.len();
         let total_start = Instant::now();
 
@@ -2258,5 +2274,32 @@ impl<
             }
         }
         pl.done();
+    }
+}
+
+#[cfg(test)]
+mod retry_state_tests {
+    use super::*;
+
+    /// The `MaxShardTooBig` retry counter is capped: the first 99 occurrences
+    /// are retried, the 100th is fatal, so a pathological configuration cannot
+    /// loop forever.
+    #[test]
+    fn max_shard_too_big_is_bounded() {
+        let mut pl = no_logging![];
+        let mut rs = RetryState {
+            prng: SmallRng::seed_from_u64(0),
+            dup_count: 0,
+            local_dup_count: 0,
+            max_shard_too_big: 0,
+            unsolvable_count: 0,
+        };
+        for i in 0..99 {
+            let r =
+                rs.handle_solve_result(Err::<(), _>(SolveError::MaxShardTooBig.into()), &mut pl);
+            assert!(matches!(r, Ok(None)), "attempt {i} should be retried");
+        }
+        let r = rs.handle_solve_result(Err::<(), _>(SolveError::MaxShardTooBig.into()), &mut pl);
+        assert!(r.is_err(), "the 100th MaxShardTooBig must be fatal");
     }
 }

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -119,6 +119,8 @@ pub struct VBuilder<D, S = [u64; 2], E = FuseLge3Shards> {
     pub(crate) max_num_threads: usize,
 
     /// Use disk-based buckets to reduce core memory usage at construction time.
+    /// Only the sequential constructors honor this; the parallel constructors
+    /// return an error if it is set.
     #[setters(generate = true)]
     offline: bool,
 
@@ -910,6 +912,10 @@ impl<
         SigVal<S, V>: RadixKey,
         S: Send,
     {
+        anyhow::ensure!(
+            !self.offline,
+            "offline mode is not supported by the parallel builder; use the sequential constructor (try_new_with_builder)"
+        );
         let mut rs = self.retry_state(pl);
         let n = keys.len();
         let total_start = Instant::now();

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -1470,6 +1470,15 @@ impl<
                                     continue;
                                 }
 
+                                // Take sole ownership of the shard's Vec: drain the Arc when
+                                // uniquely owned, otherwise clone it. The store-preserving build
+                                // path (try_build_func_and_store) iterates the store by shared
+                                // reference and hands out cloned Arcs while retaining its own, so
+                                // mutating through a raw `&mut` alias of the shared Arc is UB and
+                                // would corrupt the retained store.
+                                let mut shard_vec: Vec<SigVal<S, V>> =
+                                    Arc::try_unwrap(shard).unwrap_or_else(|arc| (*arc).clone());
+
                                 main_pl.debug(format_args!(
                                     "Analyzing shard {}/{}...",
                                     shard_index + 1,
@@ -1483,11 +1492,7 @@ impl<
                                 ));
 
                                 {
-                                    // SAFETY: The Arc has refcount 1: this thread is the
-                                    // sole owner after receiving from the channel.
-                                    let shard = unsafe {
-                                        &mut *(Arc::as_ptr(&shard) as *mut Vec<SigVal<S, V>>)
-                                    };
+                                    let shard = &mut shard_vec;
 
                                     if self.check_dups {
                                         shard.radix_sort_builder().sort();
@@ -1512,12 +1517,10 @@ impl<
                                         // that implies equality of local
                                         // signatures.
 
-                                        // SAFETY: The Arc has refcount 1 at this point
-                                        // (this thread is the sole owner after receive),
-                                        // so the mutable reference does not violate
-                                        // aliasing. The memory layout of SigVal<S, V>
-                                        // and E::SortSigVal<V> is guaranteed compatible
-                                        // by the ShardEdge trait.
+                                        // SAFETY: `shard` is an exclusive `&mut` to a Vec we own
+                                        // (`shard_vec`), so this reborrow does not alias. The memory
+                                        // layout of SigVal<S, V> and E::SortSigVal<V> is guaranteed
+                                        // compatible by the ShardEdge trait.
                                         let shard = unsafe {
                                             transmute::<
                                                 &mut Vec<SigVal<S, V>>,
@@ -1563,7 +1566,11 @@ impl<
                                     }
                                 }
 
-                                pl.done_with_count(shard.len());
+                                pl.done_with_count(shard_vec.len());
+
+                                // Re-wrap for the solver, which takes an owned Arc. The retained
+                                // store (if any) still holds its own, unmodified Arc.
+                                let shard = Arc::new(shard_vec);
 
                                 main_pl.debug(format_args!(
                                     "Solving shard {}/{}...",

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -154,6 +154,9 @@ pub struct VBuilder<D, S = [u64; 2], E = FuseLge3Shards> {
 
     /// The target relative space loss due to [ε-cost sharding].
     ///
+    /// The value must lie in the open interval (0, 1); constructors return an
+    /// error otherwise.
+    ///
     /// The default is 0.001. Setting a larger target, for example, 0.01, will
     /// increase the space overhead due to sharding, but will provide in general
     /// finer shards. This might not always happen, however, because the ε-cost
@@ -769,9 +772,12 @@ impl<
     ///
     /// [`try_populate_and_build`]: Self::try_populate_and_build
     pub(crate) fn retry_state(&mut self, pl: &mut impl ProgressLog) -> anyhow::Result<RetryState> {
+        // The ε-cost formulas divide by ln(1 - eps): eps == 0 divides by
+        // zero and eps >= 1 yields NaN, so only the open interval is
+        // meaningful. The range check also rejects NaN and ±∞.
         anyhow::ensure!(
-            self.eps.is_finite() && self.eps >= 0.0,
-            "eps must be finite and non-negative, got {}",
+            self.eps > 0.0 && self.eps < 1.0,
+            "eps must be in the open interval (0, 1), got {}",
             self.eps
         );
         self.init_shards_and_seed();

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -984,9 +984,15 @@ impl<
                 let shard_store = sig_store.into_shard_store(shard_edge.shard_high_bits())?;
                 let max_shard = shard_store.shard_sizes().max().unwrap_or(0);
 
-                // Check for pathological (5x) deviation from the target ε-cost
-                if max_shard as f64
-                    > (1.0 + 5.0 * self.eps) * num_keys as f64 / shard_edge.num_shards() as f64
+                // Check for pathological (5x) deviation from the target ε-cost.
+                // When `shard_size_hint` is set the sharding strategy is sized
+                // for the hinted workload, so the per-key average is
+                // meaningless — mirror the sequential path (see
+                // `try_populate_and_build`) and skip the check.
+                if self.shard_size_hint.is_none()
+                    && max_shard as f64
+                        > (1.0 + 5.0 * self.eps) * num_keys as f64
+                            / shard_edge.num_shards() as f64
                 {
                     Err(SolveError::MaxShardTooBig.into())
                 } else {

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -811,7 +811,10 @@ impl<
     ) {
         if !self.check_dups
             && matches!(
-                result.as_ref().err().and_then(|e| e.downcast_ref::<SolveError>()),
+                result
+                    .as_ref()
+                    .err()
+                    .and_then(|e| e.downcast_ref::<SolveError>()),
                 Some(SolveError::UnsolvableShard)
             )
         {
@@ -1026,8 +1029,7 @@ impl<
                 // `try_populate_and_build`) and skip the check.
                 if self.shard_size_hint.is_none()
                     && max_shard as f64
-                        > (1.0 + 5.0 * self.eps) * num_keys as f64
-                            / shard_edge.num_shards() as f64
+                        > (1.0 + 5.0 * self.eps) * num_keys as f64 / shard_edge.num_shards() as f64
                 {
                     Err(SolveError::MaxShardTooBig.into())
                 } else {

--- a/src/func/vbuilder.rs
+++ b/src/func/vbuilder.rs
@@ -749,6 +749,7 @@ impl<
                 )
             };
 
+            self.enable_dup_check_on_unsolvable(&result, pl);
             if let Some(r) = rs.handle_solve_result(result, pl)? {
                 let num_keys = self.num_keys;
                 pl.info(format_args!(
@@ -792,6 +793,33 @@ impl<
             max_shard_too_big: 0,
             unsolvable_count: 0,
         })
+    }
+
+    /// Enables duplicate-key detection after a shard proves unsolvable.
+    ///
+    /// With duplicate detection off (the default), duplicate keys make every
+    /// solve attempt fail identically: equal keys hash to equal signatures
+    /// under every seed, and the peeling graph cancels the duplicate edge, so
+    /// no vertex ever reaches degree one. Left alone, the retry loop would
+    /// reseed until it panics. On the first [`SolveError::UnsolvableShard`],
+    /// turn on the duplicate scan so the next retry escalates genuine
+    /// duplicate keys to [`BuildError::DuplicateKey`] instead.
+    pub(crate) fn enable_dup_check_on_unsolvable<R>(
+        &mut self,
+        result: &anyhow::Result<R>,
+        pl: &mut impl ProgressLog,
+    ) {
+        if !self.check_dups
+            && matches!(
+                result.as_ref().err().and_then(|e| e.downcast_ref::<SolveError>()),
+                Some(SolveError::UnsolvableShard)
+            )
+        {
+            self.check_dups = true;
+            pl.info(format_args!(
+                "Unsolvable shard: enabling duplicate-key detection for subsequent retries"
+            ));
+        }
     }
 
     /// Populates a shard store from keys and values, then calls a build
@@ -882,6 +910,7 @@ impl<
                 self.try_solve_once(seed, &mut populate, build_fn, pl, &mut state)
             };
 
+            self.enable_dup_check_on_unsolvable(&result, pl);
             if let Some(r) = rs.handle_solve_result(result, pl)? {
                 let num_keys = self.num_keys;
                 pl.info(format_args!(
@@ -1009,6 +1038,7 @@ impl<
                 }
             };
 
+            self.enable_dup_check_on_unsolvable(&result, pl);
             if let Some(r) = rs.handle_solve_result(result, pl)? {
                 let num_keys = self.num_keys;
                 pl.info(format_args!(

--- a/src/func/vfunc.rs
+++ b/src/func/vfunc.rs
@@ -7,7 +7,7 @@
 use value_traits::slices::SliceByValue;
 
 use super::shard_edge::FuseLge3Shards;
-use crate::bits::BitFieldVec;
+use crate::bits::{BitFieldVec, ValidateBacking};
 use crate::func::shard_edge::ShardEdge;
 use crate::traits::Word;
 use crate::utils::*;
@@ -127,6 +127,8 @@ impl<K: ?Sized + ToSig<S>, D: SliceByValue<Value: Word + BinSafe>, S: Sig, E: Sh
     /// if the signature is not the signature of a key.
     ///
     /// This method is mainly useful in the construction of compound functions.
+    ///
+    /// See [`validate`](Self::validate) before querying deserialized instances.
     #[inline]
     pub fn get_by_sig(&self, sig: S) -> D::Value {
         let edge = self.shard_edge.edge(sig);
@@ -143,9 +145,37 @@ impl<K: ?Sized + ToSig<S>, D: SliceByValue<Value: Word + BinSafe>, S: Sig, E: Sh
 
     /// Returns the value associated with the given key, or a random value if the
     /// key is not present.
+    ///
+    /// If this instance was deserialized from an untrusted source, call
+    /// [`validate`](Self::validate) first: this method performs unchecked reads
+    /// that assume the builder-established layout invariants.
     #[inline(always)]
     pub fn get(&self, key: impl Borrow<K>) -> D::Value {
         self.get_by_sig(K::to_sig(key.borrow(), self.seed))
+    }
+}
+
+impl<K: ?Sized, D: ValidateBacking, S: Sig, E: ShardEdge<S, 3>> VFunc<K, D, S, E> {
+    /// Checks the invariants relied upon by [`get`](Self::get), for use after
+    /// deserializing from an untrusted source.
+    ///
+    /// Verifies that the backing storage is internally consistent and large
+    /// enough that the unchecked edge reads performed by `get` cannot go out of
+    /// bounds. On `Ok`, `get` is memory-safe for any key; otherwise an error is
+    /// returned.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let shard_bits = self.shard_edge.shard_high_bits();
+        anyhow::ensure!(
+            shard_bits < usize::BITS,
+            "shard_high_bits {shard_bits} is too large"
+        );
+        let num_shards = 1usize << shard_bits;
+        let required = self
+            .shard_edge
+            .num_vertices()
+            .checked_mul(num_shards)
+            .ok_or_else(|| anyhow::anyhow!("num_vertices * num_shards overflows usize"))?;
+        self.data.validate_capacity(required)
     }
 }
 
@@ -791,3 +821,23 @@ mod build {
         }
     }
 } // mod build
+
+#[cfg(all(test, feature = "rayon"))]
+mod validate_tests {
+    use super::*;
+    use crate::bits::BitFieldVec;
+    use dsi_progress_logger::no_logging;
+
+    #[test]
+    fn test_validate() {
+        let keys: Vec<usize> = (0..1000).collect();
+        let values: Vec<usize> = (0..1000).collect();
+        let mut func =
+            VFunc::<usize, BitFieldVec<Box<[usize]>>>::try_par_new(&keys, &values, no_logging![])
+                .unwrap();
+        assert!(func.validate().is_ok());
+        // Truncating the data backing makes the edge reads go out of bounds.
+        func.data = BitFieldVec::<Vec<usize>>::new(10, 1).into();
+        assert!(func.validate().is_err());
+    }
+}

--- a/src/func/vfunc.rs
+++ b/src/func/vfunc.rs
@@ -164,6 +164,7 @@ impl<K: ?Sized, D: ValidateBacking, S: Sig, E: ShardEdge<S, 3>> VFunc<K, D, S, E
     /// bounds. On `Ok`, `get` is memory-safe for any key; otherwise an error is
     /// returned.
     pub fn validate(&self) -> anyhow::Result<()> {
+        self.shard_edge.validate()?;
         let shard_bits = self.shard_edge.shard_high_bits();
         anyhow::ensure!(
             shard_bits < usize::BITS,

--- a/src/func/vfunc2.rs
+++ b/src/func/vfunc2.rs
@@ -174,6 +174,8 @@ impl<
     ///
     /// This method is mainly useful in the construction of compound
     /// functions.
+    ///
+    /// See [`validate`](Self::validate) before querying deserialized instances.
     #[inline]
     pub fn get_by_sig(&self, sig: S) -> D::Value {
         let idx = self.first.get_by_sig(sig);
@@ -186,9 +188,52 @@ impl<
 
     /// Retrieves the value associated with the given key, or an arbitrary
     /// value if the key was not in the original set.
+    ///
+    /// If this instance was deserialized from an untrusted source, call
+    /// [`validate`](Self::validate) first: this method performs unchecked reads
+    /// that assume the builder-established layout invariants.
     #[inline(always)]
     pub fn get(&self, key: impl Borrow<K>) -> D::Value {
         self.get_by_sig(K::to_sig(key.borrow(), self.first.seed))
+    }
+}
+
+impl<
+    K: ?Sized,
+    D: SliceByValue<Value: Word + PrimitiveNumberAs<u128>>
+        + crate::bits::ValidateBacking
+        + crate::traits::BitWidth,
+    S: Sig,
+    E: ShardEdge<S, 3>,
+    F: ShardEdge<S, 3>,
+> VFunc2<K, D, S, E, F>
+{
+    /// Checks the invariants relied upon by [`get`](Self::get), for use after
+    /// deserializing from an untrusted source.
+    ///
+    /// Validates both underlying functions and that `remap` covers the whole
+    /// output range of the first function, so the unchecked `remap` index in
+    /// `get` cannot go out of bounds. On `Ok`, `get` is memory-safe for any key.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        self.first.validate()?;
+        self.second.validate()?;
+        let r = crate::traits::BitWidth::bit_width(&self.first.data);
+        anyhow::ensure!(r < 128, "first-function bit width {r} is too large");
+        // The first function outputs values in `[0, 2^r)`; `escape` must be its
+        // maximum `2^r - 1` so that any non-escape index is `< escape`.
+        let max = (1u128 << r) - 1;
+        anyhow::ensure!(
+            self.escape.as_to::<u128>() == max,
+            "escape does not match the first-function width"
+        );
+        let max_usize =
+            usize::try_from(max).map_err(|_| anyhow::anyhow!("escape range exceeds usize"))?;
+        anyhow::ensure!(
+            self.remap.len() >= max_usize,
+            "remap covers {} entries but {max_usize} are required",
+            self.remap.len()
+        );
+        Ok(())
     }
 }
 

--- a/src/func/vfunc2.rs
+++ b/src/func/vfunc2.rs
@@ -98,8 +98,9 @@ pub struct VFunc2<
     F = E,
 > {
     /// First function: maps each key to an index (*r* bits), or [`escape`] for
-    /// infrequent values. When *r* = 0 this is an empty VFunc that always
-    /// returns 0, so the second function is always queried.
+    /// infrequent values. When *r* = 0 the escape value is 0, so this is a
+    /// minimal one-bit function that maps every key to 0 = escape and the
+    /// second function is always queried.
     ///
     /// [`escape`]: Self::escape
     pub(crate) first: VFunc<K, D, S, E>,
@@ -393,7 +394,13 @@ mod build {
 
         // r < w <= 128; shift in u128 so this cannot overflow a 32-bit usize.
         for r in 0..w {
-            let cost_first = if r == 0 { 0.0 } else { c * n as f64 * r as f64 };
+            // The first function is built with escape = (1 << r) - 1 as its
+            // max value, so its bit width is bit_len(escape): r for r >= 1 and
+            // 1 for r == 0 (bit_len(0) == 1). Charge the real one-bit cost at
+            // r == 0 so the optimizer does not treat the still-built one-bit
+            // first stage as free and over-select r == 0.
+            let first_width = if r == 0 { 1 } else { r };
+            let cost_first = c * n as f64 * first_width as f64;
             let cost_second = c * post as f64 * w as f64;
             let cost_remap = pos as f64 * w_bits as f64;
             let cost = cost_first + cost_second + cost_remap;
@@ -926,5 +933,23 @@ mod tests {
         let sorted_vals: Vec<u64> = vec![1 << 40, 1 << 39, 1 << 38, 1 << 37];
         let r = find_optimal_r(400, 1u64 << 40, &sorted_vals, |_| 100, 64);
         assert!(r <= 64);
+    }
+
+    /// The first function built for `r == 0` is a one-bit function
+    /// (`bit_len(0) == 1`), not a free/empty stage, so `find_optimal_r` must
+    /// charge its `c * n` bits. Otherwise the old `cost_first = 0.0` model
+    /// under-prices `r == 0` by `c * n` and over-selects it: here the honest
+    /// cost makes `r == 1` win (absorbing the frequent value shrinks the
+    /// second stage by more than the remap entry costs).
+    #[test]
+    fn find_optimal_r_charges_one_bit_first_stage_at_zero() {
+        let sorted_vals: Vec<u64> = vec![1, 2];
+        let count_of = |v: u64| match v {
+            1 => 60,
+            2 => 40,
+            _ => 0,
+        };
+        let r = find_optimal_r(100, 2u64, &sorted_vals, count_of, 64);
+        assert_eq!(r, 1);
     }
 }

--- a/src/func/vfunc2.rs
+++ b/src/func/vfunc2.rs
@@ -245,7 +245,16 @@ mod build {
         default: V,
     }
 
-    impl<K: Word + PrimitiveNumberAs<usize>, V: Copy + Eq> HybridMap<K, V> {
+    impl<K: Word + PrimitiveNumberAs<usize> + PrimitiveNumberAs<u128>, V: Copy + Eq> HybridMap<K, V> {
+        /// Returns the flat-array index for `key`, or `None` when `key` does
+        /// not fit in a `usize`. Guarding on the full-width value prevents two
+        /// distinct wide keys (e.g. `u128` values differing only in their high
+        /// bits) from truncating to the same array slot.
+        #[inline(always)]
+        fn key_index(key: K) -> Option<usize> {
+            usize::try_from(key.as_to::<u128>()).ok()
+        }
+
         /// Creates a new hybrid map.
         ///
         /// * `max_key` - optional upper bound on keys. When provided,
@@ -254,7 +263,9 @@ mod build {
         pub(crate) fn new(max_key: Option<K>, default: V) -> Self {
             let mut array_len = 1 << 10;
             if let Some(mk) = max_key {
-                array_len = array_len.min(mk.as_to::<usize>() + 1);
+                if let Some(k) = Self::key_index(mk) {
+                    array_len = array_len.min(k.saturating_add(1));
+                }
             }
             Self {
                 array: vec![default; array_len],
@@ -264,21 +275,19 @@ mod build {
         }
 
         pub(crate) fn insert(&mut self, key: K, value: V) {
-            let k: usize = key.as_to();
-            if k < self.array.len() {
-                self.array[k] = value;
-            } else {
-                self.map.insert(key, value);
+            match Self::key_index(key) {
+                Some(k) if k < self.array.len() => self.array[k] = value,
+                _ => {
+                    self.map.insert(key, value);
+                }
             }
         }
 
         #[inline(always)]
         pub(crate) fn get(&self, key: K) -> V {
-            let k: usize = key.as_to();
-            if k < self.array.len() {
-                self.array[k]
-            } else {
-                self.map.get(&key).copied().unwrap_or(self.default)
+            match Self::key_index(key) {
+                Some(k) if k < self.array.len() => self.array[k],
+                _ => self.map.get(&key).copied().unwrap_or(self.default),
             }
         }
 
@@ -301,7 +310,7 @@ mod build {
         }
     }
 
-    impl<K: Word + PrimitiveNumberAs<usize>> HybridMap<K, usize> {
+    impl<K: Word + PrimitiveNumberAs<usize> + PrimitiveNumberAs<u128>> HybridMap<K, usize> {
         #[inline(always)]
         pub(crate) fn incr(&mut self, key: K) {
             self.add(key, 1);
@@ -309,11 +318,9 @@ mod build {
 
         #[inline(always)]
         pub(crate) fn add(&mut self, key: K, amount: usize) {
-            let k: usize = key.as_to();
-            if k < self.array.len() {
-                self.array[k] += amount;
-            } else {
-                *self.map.entry(key).or_insert(0) += amount;
+            match Self::key_index(key) {
+                Some(k) if k < self.array.len() => self.array[k] += amount,
+                _ => *self.map.entry(key).or_insert(0) += amount,
             }
         }
     }
@@ -339,7 +346,7 @@ mod build {
         let mut best_r = 0usize;
         let mut best_cost = f64::MAX;
 
-        // r < w <= 64, so 1usize << r never overflows.
+        // r < w <= 128; shift in u128 so this cannot overflow a 32-bit usize.
         for r in 0..w {
             let cost_first = if r == 0 { 0.0 } else { c * n as f64 * r as f64 };
             let cost_second = c * post as f64 * w as f64;
@@ -351,7 +358,9 @@ mod build {
                 best_r = r;
             }
 
-            let to_absorb = (1usize << r).min(m - pos);
+            let to_absorb = usize::try_from(1u128 << r)
+                .unwrap_or(usize::MAX)
+                .min(m - pos);
             for _ in 0..to_absorb {
                 post -= count_of(sorted_vals[pos]);
                 pos += 1;
@@ -704,7 +713,9 @@ mod build {
                 W::BITS as usize,
             );
 
-            let escape_usize = (1usize << best_r).wrapping_sub(1); // 2^r - 1
+            // Shift in u128 so best_r >= 32 cannot overflow a 32-bit usize.
+            let escape_usize =
+                usize::try_from((1u128 << best_r) - 1).expect("escape range exceeds usize");
             let escape = W::try_from(escape_usize).ok().unwrap();
             let num_frequent = escape_usize.min(m);
 
@@ -712,9 +723,9 @@ mod build {
 
             // We must cover possible outputs of the first function in [m..escape_size)
             let mut remap: Box<[W]> = vec![W::ZERO; escape_usize].into();
-            remap.as_mut().copy_from_slice(&sorted_vals[..num_frequent]);
+            remap[..num_frequent].copy_from_slice(&sorted_vals[..num_frequent]);
             let mut inv_map: HybridMap<W, W> = HybridMap::new(Some(max_value), escape);
-            for (i, &val) in remap.iter().enumerate() {
+            for (i, &val) in remap[..num_frequent].iter().enumerate() {
                 inv_map.insert(val, W::try_from(i).ok().unwrap());
             }
 
@@ -829,3 +840,46 @@ mod build {
 
 #[cfg(feature = "rayon")]
 pub(crate) use build::{HybridMap, find_optimal_r};
+
+#[cfg(all(test, feature = "rayon"))]
+mod tests {
+    use super::{HybridMap, find_optimal_r};
+
+    /// Two distinct keys that share their low `usize` bits but differ in high
+    /// bits (only representable in `u128`) must map to distinct entries rather
+    /// than colliding on the same flat-array slot.
+    #[test]
+    fn hybrid_map_distinguishes_wide_keys() {
+        let mut m: HybridMap<u128, u32> = HybridMap::new(None, 0);
+        let low = 5u128;
+        let high = (1u128 << 64) | 5; // same low 64 bits as `low`
+        m.insert(low, 111);
+        m.insert(high, 222);
+        assert_eq!(m.get(low), 111);
+        assert_eq!(m.get(high), 222);
+        assert_eq!(m.get(7), 0); // absent -> default
+    }
+
+    /// The frequency-counter path (`add`/`incr`) must also keep wide keys
+    /// distinct instead of merging their counts on a shared array slot.
+    #[test]
+    fn hybrid_map_add_distinguishes_wide_keys() {
+        let mut m: HybridMap<u128, usize> = HybridMap::new(None, 0);
+        let low = 5u128;
+        let high = (1u128 << 64) | 5;
+        m.add(low, 3);
+        m.add(high, 7);
+        m.incr(low);
+        assert_eq!(m.get(low), 4);
+        assert_eq!(m.get(high), 7);
+    }
+
+    /// A value width above 32 bits must not overflow the `1 << r` shift on
+    /// 32-bit targets (it is computed in `u128`).
+    #[test]
+    fn find_optimal_r_handles_wide_values() {
+        let sorted_vals: Vec<u64> = vec![1 << 40, 1 << 39, 1 << 38, 1 << 37];
+        let r = find_optimal_r(400, 1u64 << 40, &sorted_vals, |_| 100, 64);
+        assert!(r <= 64);
+    }
+}

--- a/src/fuzz/select.rs
+++ b/src/fuzz/select.rs
@@ -88,7 +88,11 @@ pub fn harness(mut data: Data) {
         ($struct:expr) => {{
             let sel = $struct;
             for (i, &pos) in zeros_pos.iter().enumerate() {
-                assert_eq!(sel.select_zero(i).unwrap(), pos, "select_zero({i}) is wrong");
+                assert_eq!(
+                    sel.select_zero(i).unwrap(),
+                    pos,
+                    "select_zero({i}) is wrong"
+                );
             }
         }};
     }
@@ -97,14 +101,14 @@ pub fn harness(mut data: Data) {
     // A minimal subinventory (log2 = 0) forces the spill path.
     test_select_zero!(SelectZeroAdaptConst::<_, _, 13, 0>::new(&bitvec));
     test_select_zero!(SelectZeroAdapt::new(&bitvec));
-    test_select_zero!(SelectZeroSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(
-        bitvec64.clone()
-    )));
+    test_select_zero!(SelectZeroSmall::<2, 9, _>::new(
+        RankSmall::<64, 2, 9, _>::new(bitvec64.clone())
+    ));
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{harness, Data};
+    use super::{Data, harness};
 
     /// Drive the harness over hand-picked shapes so a regression in any
     /// covered select structure surfaces without a full fuzz campaign.

--- a/src/fuzz/select.rs
+++ b/src/fuzz/select.rs
@@ -16,9 +16,15 @@ pub struct Data {
     len: usize,
 }
 
-/// get random data and check that all selects behave correctly
+/// Get random data and check that every ones-select structure agrees with the
+/// oracle on `select` (i-th one) and every zeros-select structure agrees on
+/// `select_zero` (i-th zero).
+///
+/// `len` is only capped at `2^20` (not scaled by the number of ones), so a
+/// `Data` with a large `len` and few `ones` produces the sparse, wide-span
+/// bit vectors that exercise the adaptive builders' U64-span and spill paths.
 pub fn harness(mut data: Data) {
-    data.len %= 1 << 20; // avoid out of memory, 1MB should be enough to find errors
+    data.len %= 1 << 20; // avoid out of memory, 1Mbit is enough to find errors
     data.len += 1; // avoid zero length
     let ones = data
         .ones
@@ -26,37 +32,104 @@ pub fn harness(mut data: Data) {
         .map(|value| value % data.len)
         .collect::<BTreeSet<_>>();
 
+    // usize-backed bit vector: the adaptive selects are built over a reference
+    // to it, so a single copy serves every adaptive/const variant.
     let mut bitvec = BitVec::<Vec<usize>>::new(data.len);
-    if data.len != 0 {
-        ones.iter().for_each(|value| {
-            bitvec.set(*value, true); // set bit to one
-        });
-    }
-
+    ones.iter().for_each(|value| {
+        bitvec.set(*value, true);
+    });
     let number_of_ones = bitvec.count_ones();
+    // SAFETY: `AddNumBits::from_raw_parts` requires the supplied count to equal
+    // the number of ones in the bit vector; `number_of_ones` was just computed
+    // as `bitvec.count_ones()` on this exact value, so the invariant holds.
     let bitvec = unsafe { AddNumBits::from_raw_parts(bitvec, number_of_ones) };
 
-    macro_rules! test_struct {
-        ($ty:ty) => {
-            let quantum = <$ty>::new(&bitvec);
+    // u64-backed copy: Select9 and SelectSmall wrap rank backends that own the
+    // bit vector, so they cannot borrow the shared `bitvec` above.
+    let mut bitvec64 = BitVec::<Vec<u64>>::new(data.len);
+    ones.iter().for_each(|value| {
+        bitvec64.set(*value, true);
+    });
 
-            for (i, v) in ones.iter().enumerate() {
-                assert_eq!(
-                    *v,
-                    quantum.select(i).unwrap(),
-                    "Quantum select is wrong at idx {}",
-                    i,
-                );
+    // Oracles: positions of the ones (ascending) and of the zeros (ascending).
+    let ones_pos = ones.iter().copied().collect::<Vec<_>>();
+    let zeros_pos = (0..data.len)
+        .filter(|pos| !ones.contains(pos))
+        .collect::<Vec<_>>();
+
+    // `select(i)` must return the position of the i-th one.
+    macro_rules! test_select {
+        ($struct:expr) => {{
+            let sel = $struct;
+            for (i, &pos) in ones_pos.iter().enumerate() {
+                assert_eq!(sel.select(i).unwrap(), pos, "select({i}) is wrong");
             }
-        };
+        }};
     }
-    test_struct!(SelectAdaptConst<_, _, 6>);
-    test_struct!(SelectAdaptConst<_, _, 7>);
-    test_struct!(SelectAdaptConst<_, _, 8>);
-    test_struct!(SelectAdaptConst<_, _, 9>);
-    test_struct!(SelectAdaptConst<_, _, 10>);
-    test_struct!(SelectAdaptConst<_, _, 11>);
-    test_struct!(SelectAdaptConst<_, _, 12>);
-    test_struct!(SelectAdaptConst<_, _, 13>);
-    test_struct!(SelectAdaptConst<_, _, 14>);
+    test_select!(SelectAdaptConst::<_, _, 6>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 7>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 8>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 9>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 10>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 11>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 12>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 13>::new(&bitvec));
+    test_select!(SelectAdaptConst::<_, _, 14>::new(&bitvec));
+    // A minimal subinventory (log2 = 0) forces the spill path.
+    test_select!(SelectAdaptConst::<_, _, 13, 0>::new(&bitvec));
+    test_select!(SelectAdapt::new(&bitvec));
+    test_select!(Select9::new(Rank9::new(bitvec64.clone())));
+    test_select!(SelectSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(
+        bitvec64.clone()
+    )));
+
+    // `select_zero(i)` must return the position of the i-th zero.
+    macro_rules! test_select_zero {
+        ($struct:expr) => {{
+            let sel = $struct;
+            for (i, &pos) in zeros_pos.iter().enumerate() {
+                assert_eq!(sel.select_zero(i).unwrap(), pos, "select_zero({i}) is wrong");
+            }
+        }};
+    }
+    test_select_zero!(SelectZeroAdaptConst::<_, _, 10>::new(&bitvec));
+    test_select_zero!(SelectZeroAdaptConst::<_, _, 13>::new(&bitvec));
+    // A minimal subinventory (log2 = 0) forces the spill path.
+    test_select_zero!(SelectZeroAdaptConst::<_, _, 13, 0>::new(&bitvec));
+    test_select_zero!(SelectZeroAdapt::new(&bitvec));
+    test_select_zero!(SelectZeroSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(
+        bitvec64.clone()
+    )));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{harness, Data};
+
+    /// Drive the harness over hand-picked shapes so a regression in any
+    /// covered select structure surfaces without a full fuzz campaign.
+    #[test]
+    fn test_harness_covers_edge_shapes() {
+        // All zeros: every position is a zero, no ones.
+        harness(Data {
+            ones: vec![],
+            len: 1000,
+        });
+        // Near-all ones: 0..=998 set, one trailing zero.
+        harness(Data {
+            ones: (0..999).collect(),
+            len: 999,
+        });
+        // Sparse wide span: three far-apart ones over ~200k bits exercise the
+        // adaptive builders' wide-span and spill paths on both sides.
+        harness(Data {
+            ones: vec![0, 100_000, 199_999],
+            len: 200_000,
+        });
+        // A denser irregular pattern.
+        harness(Data {
+            ones: vec![1, 2, 3, 64, 65, 4095, 4096, 8191, 12000],
+            len: 12_345,
+        });
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,9 @@ pub mod fuzz;
 
 /// Imports the most common items.
 ///
-/// Note that [`bit_field_slice`] and [`indexed_dict`] are not included in
-/// the prelude, as they may cause ambiguities in some contexts.
+/// The [`bit_field_slice`] and [`indexed_dict`] module names are re-exported so
+/// their items can be reached through the prelude, but their contents are not
+/// glob-imported, as that would cause ambiguities in some contexts.
 ///
 /// [`bit_field_slice`]: crate::traits::bit_field_slice
 /// [`indexed_dict`]: crate::traits::indexed_dict

--- a/src/list/comp_int_list.rs
+++ b/src/list/comp_int_list.rs
@@ -52,7 +52,7 @@ use crate::bits::test_unaligned_any_pos;
 use crate::dict::EliasFanoBuilder;
 use crate::dict::elias_fano::EfSeq;
 use crate::traits::iter::{IntoIteratorFrom, UncheckedIterator};
-use crate::traits::{Backend, BitVecValueOps, TryIntoUnaligned, Word};
+use crate::traits::{Backend, BitLength, BitVecValueOps, TryIntoUnaligned, Word};
 use crate::utils::PrimitiveUnsignedExt;
 use mem_dbg::*;
 use value_traits::slices::SliceByValue;
@@ -236,6 +236,69 @@ impl<B: Backend<Word: Word> + BitVecValueOps<B::Word>, D: SliceByValue<Value = u
     /// Returns the underlying delimiter structure.
     pub fn into_inner(self) -> D {
         self.delimiters
+    }
+}
+
+impl<B: Backend<Word: Word> + BitLength, D: SliceByValue<Value = u64>> CompIntList<B, D> {
+    /// Checks the structural invariants of this list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: the accessors otherwise trust the delimiter
+    /// structure and reach unchecked bit reads on malformed input.
+    ///
+    /// The check scans the whole delimiter structure (`O(n)`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self
+                .n
+                .checked_add(1)
+                .is_some_and(|expected| self.delimiters.len() == expected),
+            "the delimiter structure has {} elements instead of {} + 1",
+            self.delimiters.len(),
+            self.n
+        );
+        let mut prev = self.delimiters.index_value(0);
+        anyhow::ensure!(prev == 0, "the first delimiter is {prev} instead of 0");
+        // Stored values have their most significant bit removed, so widths
+        // are at most one less than the word width. We derive the word width
+        // from the type size because inherent `BITS` does not resolve on the
+        // generic associated type. Lossless: word widths fit u64.
+        let word_bits = core::mem::size_of::<B::Word>() * 8;
+        let max_width = word_bits as u64 - 1;
+        let mut all_widths_unaligned = true;
+        for index in 1..=self.n {
+            let cur = self.delimiters.index_value(index);
+            anyhow::ensure!(
+                cur >= prev,
+                "delimiter {index} is {cur}, smaller than its predecessor {prev}"
+            );
+            let width = cur - prev;
+            anyhow::ensure!(
+                width <= max_width,
+                "element {} has width {width}, larger than the maximum {max_width}",
+                index - 1
+            );
+            // Same predicate as `test_unaligned_any_pos!`: the width must be
+            // readable at any bit position with a single unaligned read.
+            // Lossless: width <= max_width < 128, checked just above.
+            if width as usize > word_bits - 7 {
+                all_widths_unaligned = false;
+            }
+            prev = cur;
+        }
+        anyhow::ensure!(
+            self.all_widths_unaligned == all_widths_unaligned,
+            "the unaligned-widths flag is {} but the stored widths say {}",
+            self.all_widths_unaligned,
+            all_widths_unaligned
+        );
+        // Lossless: usize fits u64 on all supported targets.
+        anyhow::ensure!(
+            prev <= self.data.len() as u64,
+            "the last delimiter {prev} exceeds the data bit length {}",
+            self.data.len()
+        );
+        Ok(())
     }
 }
 

--- a/src/list/comp_int_list.rs
+++ b/src/list/comp_int_list.rs
@@ -249,8 +249,7 @@ impl<B: Backend<Word: Word> + BitLength, D: SliceByValue<Value = u64>> CompIntLi
     /// The check scans the whole delimiter structure (`O(n)`).
     pub fn validate(&self) -> anyhow::Result<()> {
         anyhow::ensure!(
-            self
-                .n
+            self.n
                 .checked_add(1)
                 .is_some_and(|expected| self.delimiters.len() == expected),
             "the delimiter structure has {} elements instead of {} + 1",

--- a/src/list/comp_int_list.rs
+++ b/src/list/comp_int_list.rs
@@ -279,11 +279,7 @@ where
         self,
     ) -> Result<Self::Unaligned, crate::traits::UnalignedConversionError> {
         if !self.all_widths_unaligned {
-            return Err(crate::traits::UnalignedConversionError(
-                "CompIntList contains values whose bit widths do not satisfy the \
-                 constraints for unaligned reads"
-                    .to_string(),
-            ));
+            return Err(crate::traits::UnalignedConversionError::MixedBitWidths);
         }
 
         Ok(CompIntList {

--- a/src/list/comp_int_list.rs
+++ b/src/list/comp_int_list.rs
@@ -259,7 +259,7 @@ where
         let end = unsafe { iter.next_unchecked() } as usize;
         let width = end - start;
 
-        let bits = unsafe { self.data.get_value_unchecked(start, width) };
+        let bits = unsafe { self.data.get_bits_unchecked(start, width) };
         let stored = (B::Word::ONE << width) | bits;
 
         // stored = value - min + 1, so value = (stored - 1) + min

--- a/src/list/prefix_sum_int_list.rs
+++ b/src/list/prefix_sum_int_list.rs
@@ -148,10 +148,9 @@ impl<H: AsRef<[usize]> + SelectUnchecked, L: SliceByValue<Value = usize>>
     From<EliasFano<usize, H, L>> for PrefixSumIntList<EliasFano<usize, H, L>>
 {
     fn from(elias_fano: EliasFano<usize, H, L>) -> Self {
-        PrefixSumIntList {
-            n: elias_fano.len() - 1,
-            prefix_sums: elias_fano,
-        }
+        Self::try_from_prefix_sums(elias_fano).expect(
+            "EliasFano is not a valid prefix-sum sequence (must be non-empty with a zero first element and nondecreasing values)",
+        )
     }
 }
 

--- a/src/list/prefix_sum_int_list.rs
+++ b/src/list/prefix_sum_int_list.rs
@@ -186,6 +186,39 @@ impl<D: SliceByValue<Value = usize>> PrefixSumIntList<D> {
 }
 
 impl<D: SliceByValue<Value = usize>> PrefixSumIntList<D> {
+    /// Checks the structural invariants of this list.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: the accessors otherwise trust the cached
+    /// length and the monotonicity of the prefix sums, and can underflow on
+    /// malformed input.
+    ///
+    /// The check scans the whole prefix-sum structure (`O(n)`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let len = self.prefix_sums.len();
+        anyhow::ensure!(
+            self
+                .n
+                .checked_add(1)
+                .is_some_and(|expected| len == expected),
+            "the prefix-sum structure has {len} elements instead of {} + 1",
+            self.n
+        );
+        let mut prev = self.prefix_sums.index_value(0);
+        anyhow::ensure!(prev == 0, "the first prefix sum is {prev} instead of 0");
+        for index in 1..len {
+            let cur = self.prefix_sums.index_value(index);
+            anyhow::ensure!(
+                cur >= prev,
+                "prefix sum {index} is {cur}, smaller than its predecessor {prev}"
+            );
+            prev = cur;
+        }
+        Ok(())
+    }
+}
+
+impl<D: SliceByValue<Value = usize>> PrefixSumIntList<D> {
     /// Replaces the prefix-sum structure.
     ///
     /// # Safety

--- a/src/list/prefix_sum_int_list.rs
+++ b/src/list/prefix_sum_int_list.rs
@@ -197,8 +197,7 @@ impl<D: SliceByValue<Value = usize>> PrefixSumIntList<D> {
     pub fn validate(&self) -> anyhow::Result<()> {
         let len = self.prefix_sums.len();
         anyhow::ensure!(
-            self
-                .n
+            self.n
                 .checked_add(1)
                 .is_some_and(|expected| len == expected),
             "the prefix-sum structure has {len} elements instead of {} + 1",

--- a/src/rank_sel/mod.rs
+++ b/src/rank_sel/mod.rs
@@ -130,3 +130,22 @@ pub use rank9::*;
 
 mod select9;
 pub use select9::*;
+
+use crate::traits::Word;
+
+/// Masks the dirty padding bits of `word` when it is the final word of a bit
+/// vector whose logical length is not a multiple of the word bit-size.
+///
+/// A valid [`BitVec`](crate::bits::BitVec) may legally carry arbitrary bits
+/// past its logical length (its own `count_ones` masks them), so rank/select
+/// builders that sum raw word populations must mask the final word or they
+/// over-count. `residual` is `len % W::BITS` (0 when the last word is full).
+#[inline(always)]
+pub(crate) fn mask_tail_word<W: Word>(word: W, is_last: bool, residual: usize) -> W {
+    if is_last && residual != 0 {
+        // Keep only the low `residual` logical bits of the final word.
+        word & (W::MAX >> (W::BITS as usize - residual))
+    } else {
+        word
+    }
+}

--- a/src/rank_sel/rank9.rs
+++ b/src/rank_sel/rank9.rs
@@ -235,9 +235,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength> Rank9<B, Box<[BlockC
     }
 }
 
-impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength, C: AsRef<[BlockCounters]>>
-    Rank9<B, C>
-{
+impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength, C: AsRef<[BlockCounters]>> Rank9<B, C> {
     /// Checks that the rank counters are consistent with the bit vector.
     ///
     /// After deserializing from an untrusted or possibly stale source, call

--- a/src/rank_sel/rank9.rs
+++ b/src/rank_sel/rank9.rs
@@ -235,6 +235,74 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength> Rank9<B, Box<[BlockC
     }
 }
 
+impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength, C: AsRef<[BlockCounters]>>
+    Rank9<B, C>
+{
+    /// Checks that the rank counters are consistent with the bit vector.
+    ///
+    /// After deserializing from an untrusted or possibly stale source, call
+    /// this method before use: rank queries otherwise trust the counters and
+    /// can report out-of-range ranks on malformed input.
+    ///
+    /// The check rescans the whole bit vector (`O(len)`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let num_bits = self.bits.len();
+        let num_words = num_bits.div_ceil(64);
+        let residual = num_bits % 64;
+        let num_counts = num_bits.div_ceil(64 * Self::WORDS_PER_BLOCK);
+        let counts = self.counts.as_ref();
+        let words = self.bits.as_ref();
+        anyhow::ensure!(
+            counts.len() == num_counts + 1,
+            "wrong number of block counters: {} for {} bits",
+            counts.len(),
+            num_bits
+        );
+        anyhow::ensure!(
+            words.len() >= num_words,
+            "the backend has {} words, too few for {} bits",
+            words.len(),
+            num_bits
+        );
+        let mut num_ones: u64 = 0;
+        for (block, count) in counts[..num_counts].iter().enumerate() {
+            let i = block * Self::WORDS_PER_BLOCK;
+            anyhow::ensure!(
+                count.absolute == num_ones,
+                "block {block}: absolute counter is {} instead of {num_ones}",
+                count.absolute
+            );
+            anyhow::ensure!(
+                count.rel(0) == 0,
+                "block {block}: relative counter 0 is {} instead of 0",
+                count.rel(0)
+            );
+            num_ones +=
+                u64::from(mask_tail_word(words[i], i + 1 == num_words, residual).count_ones());
+            for j in 1..8 {
+                // Lossless: a relative count within a block is at most 512.
+                let rel_count = (num_ones - count.absolute) as usize;
+                anyhow::ensure!(
+                    count.rel(j) == rel_count,
+                    "block {block}: relative counter {j} is {} instead of {rel_count}",
+                    count.rel(j)
+                );
+                if i + j < num_words {
+                    num_ones += u64::from(
+                        mask_tail_word(words[i + j], i + j + 1 == num_words, residual).count_ones(),
+                    );
+                }
+            }
+        }
+        anyhow::ensure!(
+            counts[num_counts].absolute == num_ones,
+            "the total counter is {} instead of {num_ones}",
+            counts[num_counts].absolute
+        );
+        Ok(())
+    }
+}
+
 impl<B, C> Deref for Rank9<B, C> {
     type Target = B;
 
@@ -338,6 +406,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength, C: AsRef<[BlockCount
 mod tests {
     use super::*;
     use crate::traits::BitCount;
+    use crate::traits::BitVecOpsMut;
     #[test]
     fn test_last() {
         let bits = unsafe { BitVec::from_raw_parts(vec![!1u64; 1 << 10], (1 << 10) * 64) };
@@ -345,5 +414,31 @@ mod tests {
         let rank9 = Rank9::new(bits);
 
         assert_eq!(rank9.rank(rank9.len()), rank9.bits.count_ones());
+    }
+
+    #[test]
+    fn test_validate() -> anyhow::Result<()> {
+        let mut bits = BitVec::<Vec<u64>>::new(1000);
+        for i in (0..1000).step_by(3) {
+            bits.set(i, true);
+        }
+        let rank9 = Rank9::new(bits);
+        rank9.validate()?;
+
+        // Corrupt an absolute counter: the total is unchanged, but ranks
+        // inside the block are shifted.
+        let mut corrupt = rank9.clone();
+        let mut counts = corrupt.counts.to_vec();
+        counts[1].absolute += 1;
+        corrupt.counts = counts.into_boxed_slice();
+        assert!(corrupt.validate().is_err());
+
+        // Corrupt a relative counter lane.
+        let mut corrupt = rank9;
+        let mut counts = corrupt.counts.to_vec();
+        counts[0].relative ^= 1 << 9;
+        corrupt.counts = counts.into_boxed_slice();
+        assert!(corrupt.validate().is_err());
+        Ok(())
     }
 }

--- a/src/rank_sel/rank9.rs
+++ b/src/rank_sel/rank9.rs
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+use super::mask_tail_word;
 use crate::prelude::*;
 use crate::traits::{Backend, Word};
 use ambassador::Delegate;
@@ -193,6 +194,7 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength> Rank9<B, Box<[BlockC
         const { assert!(size_of::<B::Word>() == 8, "Rank9 requires 64-bit words") }
         let num_bits = bits.len();
         let num_words = num_bits.div_ceil(64);
+        let residual = num_bits % 64;
         let num_counts = num_bits.div_ceil(64 * Self::WORDS_PER_BLOCK);
 
         // We use the last counter to store the total number of ones
@@ -205,13 +207,16 @@ impl<B: Backend<Word: Word> + AsRef<[B::Word]> + BitLength> Rank9<B, Box<[BlockC
                 absolute: num_ones,
                 relative: 0,
             };
-            num_ones += bits.as_ref()[i].count_ones() as u64;
+            num_ones +=
+                mask_tail_word(bits.as_ref()[i], i + 1 == num_words, residual).count_ones() as u64;
 
             for j in 1..8 {
                 let rel_count = (num_ones - count.absolute) as usize;
                 count.set_rel(j, rel_count);
                 if i + j < num_words {
-                    num_ones += bits.as_ref()[i + j].count_ones() as u64;
+                    num_ones +=
+                        mask_tail_word(bits.as_ref()[i + j], i + j + 1 == num_words, residual)
+                            .count_ones() as u64;
                 }
             }
 

--- a/src/rank_sel/rank_small.rs
+++ b/src/rank_sel/rank_small.rs
@@ -22,6 +22,7 @@ use crate::{
     },
 };
 
+use super::mask_tail_word;
 use crate::ambassador_impl_Index;
 use crate::traits::ambassador_impl_Backend;
 use crate::traits::bal_paren::{BalParen, ambassador_impl_BalParen};
@@ -624,6 +625,7 @@ macro_rules! impl_rank_small {
                 let bits_per_word = B::Word::BITS as usize;
                 let num_bits = bits.len();
                 let num_words = num_bits.div_ceil(bits_per_word);
+                let residual = num_bits % bits_per_word;
                 let num_upper_counts = (num_bits as u64).div_ceil(1u64 << 32) as usize;
                 let num_counts = num_bits.div_ceil(bits_per_word * Self::WORDS_PER_BLOCK);
 
@@ -643,7 +645,8 @@ macro_rules! impl_rank_small {
                     }
                     let mut count = Block32Counters::<$NUM_U32S, $COUNTER_WIDTH>::default();
                     count.absolute = (past_ones - upper_count) as u32;
-                    past_ones += bits.as_ref()[i].count_ones() as usize;
+                    past_ones += mask_tail_word(bits.as_ref()[i], i + 1 == num_words, residual)
+                        .count_ones() as usize;
 
                     for j in 1..Self::WORDS_PER_BLOCK {
                         #[allow(clippy::modulo_one)]
@@ -652,7 +655,12 @@ macro_rules! impl_rank_small {
                             count.set_rel(j / Self::WORDS_PER_SUBBLOCK, rel_count);
                         }
                         if i + j < num_words {
-                            past_ones += bits.as_ref()[i + j].count_ones() as usize;
+                            past_ones += mask_tail_word(
+                                bits.as_ref()[i + j],
+                                i + j + 1 == num_words,
+                                residual,
+                            )
+                            .count_ones() as usize;
                         }
                     }
 

--- a/src/rank_sel/select9.rs
+++ b/src/rank_sel/select9.rs
@@ -196,6 +196,7 @@ impl<
         const { assert!(size_of::<B::Word>() == 8, "Select9 requires 64-bit words") }
         let num_bits = rank9.len();
         let num_words = num_bits.div_ceil(64);
+        let residual = num_bits % 64;
         let inventory_size = rank9.num_ones().div_ceil(Self::ONES_PER_INVENTORY);
 
         let u64_per_subinventory = 4;
@@ -208,6 +209,7 @@ impl<
         let mut curr_num_ones = 0;
         let mut next_quantum = 0;
         for (i, word) in rank9.bits.as_ref().iter().copied().enumerate() {
+            let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 
             while curr_num_ones + ones_in_word > next_quantum {

--- a/src/rank_sel/select9.rs
+++ b/src/rank_sel/select9.rs
@@ -208,7 +208,16 @@ impl<
         // construct the inventory
         let mut curr_num_ones = 0;
         let mut next_quantum = 0;
-        for (i, word) in rank9.bits.as_ref().iter().copied().enumerate() {
+        // Bound the scan to the logical words: the backing may legally hold
+        // stale words past `len().div_ceil(64)` (e.g. after `pop`/`resize`).
+        for (i, word) in rank9
+            .bits
+            .as_ref()
+            .iter()
+            .copied()
+            .take(num_words)
+            .enumerate()
+        {
             let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 

--- a/src/rank_sel/select_adapt.rs
+++ b/src/rank_sel/select_adapt.rs
@@ -952,12 +952,15 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
                         SpanType::U64 => {
                             if subinventory_idx < words_per_subinventory {
                                 inventory[start_inv_idx + 1 + subinventory_idx] = bit_index;
-                                subinventory_idx += 1;
                             } else {
                                 assert!(spilled < spill_size);
                                 spill[spilled] = bit_index;
                                 spilled += 1;
                             }
+                            // Count every stored one (local or spilled) so the
+                            // early exit below can fire; the local-vs-spill
+                            // routing above is unchanged.
+                            subinventory_idx += 1;
                             // This exit is not necessary for correctness, but
                             // it avoids the additional loop iterations that
                             // would be necessary to find the position of the

--- a/src/rank_sel/select_adapt.rs
+++ b/src/rank_sel/select_adapt.rs
@@ -738,11 +738,13 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
         let mut spilled = 0;
 
         let bits_per_word = B::Word::BITS as usize;
-        let num_words = bits.as_ref().len();
+        // Logical word count: the backing may legally hold stale words past
+        // `len().div_ceil(bits_per_word)` (e.g. after `pop`/`resize`).
+        let num_words = bits.len().div_ceil(bits_per_word);
         let residual = bits.len() % bits_per_word;
 
         // First phase: we build an inventory for each one out of ones_per_inventory.
-        for (i, word) in bits.as_ref().iter().copied().enumerate() {
+        for (i, word) in bits.as_ref().iter().copied().take(num_words).enumerate() {
             let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 

--- a/src/rank_sel/select_adapt.rs
+++ b/src/rank_sel/select_adapt.rs
@@ -687,6 +687,11 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
             overhead_percentage > 0.0,
             "overhead_percentage must be positive"
         );
+        assert!(
+            max_log2_words_per_subinv < usize::BITS as usize,
+            "max_log2_words_per_subinv ({max_log2_words_per_subinv}) must be less than {}",
+            usize::BITS
+        );
         let m = 1usize << max_log2_words_per_subinv;
 
         // Target span from overhead: overhead% = (1+M) · usize::BITS / T · 100
@@ -708,6 +713,16 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
         max_log2_words_per_subinventory: usize,
     ) -> Self {
         assert_inventory_length(bits.len());
+        assert!(
+            log2_ones_per_inventory < usize::BITS as usize,
+            "log2_ones_per_inventory ({log2_ones_per_inventory}) must be less than {}",
+            usize::BITS
+        );
+        assert!(
+            max_log2_words_per_subinventory < usize::BITS as usize,
+            "max_log2_words_per_subinventory ({max_log2_words_per_subinventory}) must be less than {}",
+            usize::BITS
+        );
         let num_bits = max(1, bits.len());
         let ones_per_inventory = 1 << log2_ones_per_inventory;
         let ones_per_inventory_mask = ones_per_inventory - 1;

--- a/src/rank_sel/select_adapt.rs
+++ b/src/rank_sel/select_adapt.rs
@@ -738,9 +738,12 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
         let mut spilled = 0;
 
         let bits_per_word = B::Word::BITS as usize;
+        let num_words = bits.as_ref().len();
+        let residual = bits.len() % bits_per_word;
 
         // First phase: we build an inventory for each one out of ones_per_inventory.
         for (i, word) in bits.as_ref().iter().copied().enumerate() {
+            let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 
             while past_ones + ones_in_word > next_quantum {

--- a/src/rank_sel/select_adapt_const.rs
+++ b/src/rank_sel/select_adapt_const.rs
@@ -516,12 +516,15 @@ impl<
                         SpanType::U64 => {
                             if subinventory_idx < words_per_subinventory {
                                 inventory[start_inv_idx + 1 + subinventory_idx] = bit_index;
-                                subinventory_idx += 1;
                             } else {
                                 assert!(spilled < spill_size);
                                 spill[spilled] = bit_index;
                                 spilled += 1;
                             }
+                            // Count every stored one (local or spilled) so the
+                            // early exit below can fire; the local-vs-spill
+                            // routing above is unchanged.
+                            subinventory_idx += 1;
                             // This exit is not necessary for correctness, but
                             // it avoids the additional loop iterations that
                             // would be necessary to find the position of the

--- a/src/rank_sel/select_adapt_const.rs
+++ b/src/rank_sel/select_adapt_const.rs
@@ -225,6 +225,13 @@ impl<B, I, const LOG2_ONES_PER_INVENTORY: usize, const LOG2_WORDS_PER_SUBINVENTO
     const ONES_PER_SUB16_MASK: usize = (1 << Self::LOG2_ONES_PER_SUB16) - 1;
     const ONES_PER_INVENTORY: usize = (1 << LOG2_ONES_PER_INVENTORY);
     const ONES_PER_INVENTORY_MASK: usize = (1 << LOG2_ONES_PER_INVENTORY) - 1;
+    /// Compile-time check that the const parameters are valid shift amounts.
+    /// `usize::BITS as usize` is a lossless u32->usize widening.
+    const PARAMS_OK: () = assert!(
+        LOG2_ONES_PER_INVENTORY < usize::BITS as usize
+            && LOG2_WORDS_PER_SUBINVENTORY < usize::BITS as usize,
+        "LOG2_ONES_PER_INVENTORY and LOG2_WORDS_PER_SUBINVENTORY must be less than the word width"
+    );
 
     /// Computes adaptively the number of 32-bit subinventory entries
     #[inline(always)]
@@ -292,6 +299,8 @@ impl<
     #[must_use]
     pub fn new(bits: B) -> Self {
         assert_inventory_length(bits.len());
+        // Force the const-parameter validity check.
+        let () = Self::PARAMS_OK;
         let num_ones = bits.count_ones();
         let num_bits = max(1, bits.len());
         let inventory_size = num_ones.div_ceil(Self::ONES_PER_INVENTORY);

--- a/src/rank_sel/select_adapt_const.rs
+++ b/src/rank_sel/select_adapt_const.rs
@@ -308,11 +308,13 @@ impl<
         let mut spilled = 0;
 
         let bits_per_word = B::Word::BITS as usize;
-        let num_words = bits.as_ref().len();
+        // Logical word count: the backing may legally hold stale words past
+        // `len().div_ceil(bits_per_word)` (e.g. after `pop`/`resize`).
+        let num_words = bits.len().div_ceil(bits_per_word);
         let residual = bits.len() % bits_per_word;
 
         // First phase: we build an inventory for each one out of ones_per_inventory.
-        for (i, word) in bits.as_ref().iter().copied().enumerate() {
+        for (i, word) in bits.as_ref().iter().copied().take(num_words).enumerate() {
             let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 

--- a/src/rank_sel/select_adapt_const.rs
+++ b/src/rank_sel/select_adapt_const.rs
@@ -308,9 +308,12 @@ impl<
         let mut spilled = 0;
 
         let bits_per_word = B::Word::BITS as usize;
+        let num_words = bits.as_ref().len();
+        let residual = bits.len() % bits_per_word;
 
         // First phase: we build an inventory for each one out of ones_per_inventory.
         for (i, word) in bits.as_ref().iter().copied().enumerate() {
+            let word = super::mask_tail_word(word, i + 1 == num_words, residual);
             let ones_in_word = word.count_ones() as usize;
 
             while past_ones + ones_in_word > next_quantum {

--- a/src/rank_sel/select_small.rs
+++ b/src/rank_sel/select_small.rs
@@ -250,7 +250,11 @@ macro_rules! impl_rank_small_sel {
             fn _new(small_counters: C, num_ones: usize, log2_ones_per_inventory: usize) -> Self {
                 let bits_per_word = C::Word::BITS as usize;
                 let num_bits = small_counters.len();
-                let num_words = small_counters.as_ref().len();
+                // Logical word count: the backing may legally hold stale words
+                // past `len().div_ceil(bits_per_word)` (e.g. after
+                // `pop`/`resize`); slicing below is in-bounds because logical
+                // words never exceed physical words for a valid bit vector.
+                let num_words = num_bits.div_ceil(bits_per_word);
                 let residual = num_bits % bits_per_word;
                 let words_per_superblock = Self::SUPERBLOCK_BIT_SIZE / bits_per_word;
                 let ones_per_inventory = 1 << log2_ones_per_inventory;
@@ -272,8 +276,7 @@ macro_rules! impl_rank_small_sel {
                 let mut past_ones: usize = 0;
                 let mut next_quantum: usize = 0;
 
-                for (sb, superblock) in small_counters
-                    .as_ref()
+                for (sb, superblock) in small_counters.as_ref()[..num_words]
                     .chunks(words_per_superblock)
                     .enumerate()
                 {

--- a/src/rank_sel/select_small.rs
+++ b/src/rank_sel/select_small.rs
@@ -249,6 +249,10 @@ macro_rules! impl_rank_small_sel {
 
             fn _new(small_counters: C, num_ones: usize, log2_ones_per_inventory: usize) -> Self {
                 let bits_per_word = C::Word::BITS as usize;
+                let num_bits = small_counters.len();
+                let num_words = small_counters.as_ref().len();
+                let residual = num_bits % bits_per_word;
+                let words_per_superblock = Self::SUPERBLOCK_BIT_SIZE / bits_per_word;
                 let ones_per_inventory = 1 << log2_ones_per_inventory;
                 // half_ones is the midpoint within each inventory interval. We advance
                 // next_quantum by half_ones each step, alternating between primary and
@@ -268,12 +272,16 @@ macro_rules! impl_rank_small_sel {
                 let mut past_ones: usize = 0;
                 let mut next_quantum: usize = 0;
 
-                for superblock in small_counters
+                for (sb, superblock) in small_counters
                     .as_ref()
-                    .chunks(Self::SUPERBLOCK_BIT_SIZE / bits_per_word)
+                    .chunks(words_per_superblock)
+                    .enumerate()
                 {
                     let mut first = true;
                     for (i, word) in superblock.iter().copied().enumerate() {
+                        let global_word = sb * words_per_superblock + i;
+                        let word =
+                            super::mask_tail_word(word, global_word + 1 == num_words, residual);
                         let ones_in_word = word.count_ones() as usize;
 
                         while past_ones + ones_in_word > next_quantum {

--- a/src/rank_sel/select_small.rs
+++ b/src/rank_sel/select_small.rs
@@ -235,6 +235,7 @@ macro_rules! impl_rank_small_sel {
             /// [`RankSmall`] blocks per inventory on average.
             #[must_use]
             pub fn with_inv(small_counters: C, blocks_per_inv: usize) -> Self {
+                assert!(blocks_per_inv > 0, "blocks_per_inv must be positive");
                 let num_bits = small_counters.len();
                 let num_ones = small_counters.num_ones();
 
@@ -325,7 +326,9 @@ macro_rules! impl_rank_small_sel {
                     inventory.push(0);
                     inventory_begin.push(0);
                 } else {
-                    inventory_begin.push(small_counters.as_ref().len());
+                    // The sentinel bounds an inventory index, so it must be the
+                    // inventory length, not the backing word count.
+                    inventory_begin.push(inventory.len());
                 }
 
                 let inventory = inventory.into_boxed_slice();

--- a/src/rank_sel/select_zero_adapt.rs
+++ b/src/rank_sel/select_zero_adapt.rs
@@ -558,12 +558,15 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
                         SpanType::U64 => {
                             if subinventory_idx < words_per_subinventory {
                                 inventory[start_inv_idx + 1 + subinventory_idx] = bit_index;
-                                subinventory_idx += 1;
                             } else {
                                 assert!(spilled < spill_size);
                                 spill[spilled] = bit_index;
                                 spilled += 1;
                             }
+                            // Count every stored zero (local or spilled) so the
+                            // early exit below can fire; the local-vs-spill
+                            // routing above is unchanged.
+                            subinventory_idx += 1;
                             // This exit is not necessary for correctness, but
                             // it avoids the additional loop iterations that
                             // would be necessary to find the position of the

--- a/src/rank_sel/select_zero_adapt.rs
+++ b/src/rank_sel/select_zero_adapt.rs
@@ -303,6 +303,11 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
             overhead_percentage > 0.0,
             "overhead_percentage must be positive"
         );
+        assert!(
+            max_log2_words_per_subinv < usize::BITS as usize,
+            "max_log2_words_per_subinv ({max_log2_words_per_subinv}) must be less than {}",
+            usize::BITS
+        );
         let m = 1usize << max_log2_words_per_subinv;
 
         let target_span =
@@ -319,6 +324,16 @@ impl<B: Backend<Word: Word + SelectInWord> + AsRef<[B::Word]> + BitCount>
         max_log2_words_per_subinventory: usize,
     ) -> Self {
         assert_inventory_length(bits.len());
+        assert!(
+            log2_ones_per_inventory < usize::BITS as usize,
+            "log2_ones_per_inventory ({log2_ones_per_inventory}) must be less than {}",
+            usize::BITS
+        );
+        assert!(
+            max_log2_words_per_subinventory < usize::BITS as usize,
+            "max_log2_words_per_subinventory ({max_log2_words_per_subinventory}) must be less than {}",
+            usize::BITS
+        );
         let num_bits = max(1, bits.len());
         let ones_per_inventory = 1 << log2_ones_per_inventory;
         let ones_per_inventory_mask = ones_per_inventory - 1;

--- a/src/rank_sel/select_zero_adapt_const.rs
+++ b/src/rank_sel/select_zero_adapt_const.rs
@@ -206,6 +206,13 @@ impl<B, I, const LOG2_ZEROS_PER_INVENTORY: usize, const LOG2_WORDS_PER_SUBINVENT
     const ONES_PER_SUB16_MASK: usize = (1 << Self::LOG2_ONES_PER_SUB16) - 1;
     const ONES_PER_INVENTORY: usize = (1 << LOG2_ZEROS_PER_INVENTORY);
     const ONES_PER_INVENTORY_MASK: usize = (1 << LOG2_ZEROS_PER_INVENTORY) - 1;
+    /// Compile-time check that the const parameters are valid shift amounts.
+    /// `usize::BITS as usize` is a lossless u32->usize widening.
+    const PARAMS_OK: () = assert!(
+        LOG2_ZEROS_PER_INVENTORY < usize::BITS as usize
+            && LOG2_WORDS_PER_SUBINVENTORY < usize::BITS as usize,
+        "LOG2_ZEROS_PER_INVENTORY and LOG2_WORDS_PER_SUBINVENTORY must be less than the word width"
+    );
 
     // Compute adaptively the number of 32-bit subinventory entries
     #[inline(always)]
@@ -270,6 +277,8 @@ impl<
     #[must_use]
     pub fn new(bits: B) -> Self {
         assert_inventory_length(bits.len());
+        // Force the const-parameter validity check.
+        let () = Self::PARAMS_OK;
         let num_ones = bits.count_zeros();
         let num_bits = max(1, bits.len());
         let inventory_size = num_ones.div_ceil(Self::ONES_PER_INVENTORY);

--- a/src/rank_sel/select_zero_adapt_const.rs
+++ b/src/rank_sel/select_zero_adapt_const.rs
@@ -489,12 +489,15 @@ impl<
                         SpanType::U64 => {
                             if subinventory_idx < words_per_subinventory {
                                 inventory[start_inv_idx + 1 + subinventory_idx] = bit_index;
-                                subinventory_idx += 1;
                             } else {
                                 assert!(spilled < spill_size);
                                 spill[spilled] = bit_index;
                                 spilled += 1;
                             }
+                            // Count every stored zero (local or spilled) so the
+                            // early exit below can fire; the local-vs-spill
+                            // routing above is unchanged.
+                            subinventory_idx += 1;
                             // This exit is not necessary for correctness, but
                             // it avoids the additional loop iterations that
                             // would be necessary to find the position of the

--- a/src/rank_sel/select_zero_small.rs
+++ b/src/rank_sel/select_zero_small.rs
@@ -182,6 +182,7 @@ macro_rules! impl_select_zero_small {
             /// [`RankSmall`] blocks per inventory on average.
             #[must_use]
             pub fn with_inv(small_counters: C, blocks_per_inv: usize) -> Self {
+                assert!(blocks_per_inv > 0, "blocks_per_inv must be positive");
                 let num_bits = small_counters.len();
                 let num_ones = small_counters.len() - small_counters.num_ones();
 
@@ -252,7 +253,9 @@ macro_rules! impl_select_zero_small {
                     inventory.push(0);
                     inventory_begin.push(0 as usize);
                 } else {
-                    inventory_begin.push(small_counters.as_ref().len() as usize);
+                    // The sentinel bounds an inventory index, so it must be the
+                    // inventory length, not the backing word count.
+                    inventory_begin.push(inventory.len());
                 }
 
                 let inventory = inventory.into_boxed_slice();

--- a/src/traits/bit_vec_ops.rs
+++ b/src/traits/bit_vec_ops.rs
@@ -103,7 +103,7 @@ pub trait BitVecOps<W: Word>: AsRef<[W]> + BitLength {
         (word >> (index % bits_per_word)) & W::ONE != W::ZERO
     }
 
-    /// Like [`BitVecValueOps::get_value`], but using a branchless unaligned
+    /// Like [`BitVecValueOps::get_bits`], but using a branchless unaligned
     /// read.
     ///
     /// The read loads one full word starting at byte offset `pos / 8`,
@@ -153,7 +153,7 @@ pub trait BitVecOps<W: Word>: AsRef<[W]> + BitLength {
         unsafe { self.get_value_unaligned_unchecked(pos, width) }
     }
 
-    /// Like [`BitVecValueOps::get_value_unchecked`], but using a
+    /// Like [`BitVecValueOps::get_bits_unchecked`], but using a
     /// branchless unaligned read.
     ///
     /// See [`get_value_unaligned`](Self::get_value_unaligned) for the
@@ -389,7 +389,7 @@ pub trait BitVecValueOps<W: Word> {
     ///
     /// Panics if `pos + width` exceeds the bit length or if `width` >
     /// `W::BITS`.
-    fn get_value(&self, pos: usize, width: usize) -> W;
+    fn get_bits(&self, pos: usize, width: usize) -> W;
 
     /// Reads `width` bits starting at bit position `pos`, without bounds
     /// checks.
@@ -399,7 +399,7 @@ pub trait BitVecValueOps<W: Word> {
     /// - `pos + width` must not exceed the bit length of the underlying
     ///   storage.
     /// - `width` must be at most `W::BITS`.
-    unsafe fn get_value_unchecked(&self, pos: usize, width: usize) -> W;
+    unsafe fn get_bits_unchecked(&self, pos: usize, width: usize) -> W;
 }
 
 /// An iterator over the bits of a bit vector as booleans.

--- a/src/traits/bit_vec_ops.rs
+++ b/src/traits/bit_vec_ops.rs
@@ -440,6 +440,12 @@ impl<W: Word, B: ?Sized + AsRef<[W]>> Iterator for BitIter<'_, W, B> {
         self.next_bit_pos += 1;
         Some(bit != W::ZERO)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.len - self.next_bit_pos;
+        (rem, Some(rem))
+    }
 }
 
 impl<W: Word, B: ?Sized + AsRef<[W]>> ExactSizeIterator for BitIter<'_, W, B> {
@@ -860,6 +866,12 @@ impl<A: PrimitiveAtomicUnsigned<Value: Word>, B: ?Sized + AsRef<[A]>> Iterator
         let bit = (word >> bit_idx) & A::Value::ONE;
         self.next_bit_pos += 1;
         Some(bit != A::Value::ZERO)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.len - self.next_bit_pos;
+        (rem, Some(rem))
     }
 }
 

--- a/src/traits/bit_vec_ops.rs
+++ b/src/traits/bit_vec_ops.rs
@@ -138,11 +138,14 @@ pub trait BitVecOps<W: Word>: AsRef<[W]> + BitLength {
             stringify!(W),
             W::BITS as usize,
         );
+        let end = pos
+            .checked_add(width)
+            .expect("bit range end (pos + width) overflows usize");
         assert!(
-            pos + width <= self.len(),
+            end <= self.len(),
             "bit range {}..{} out of bounds for length {}",
             pos,
-            pos + width,
+            end,
             self.len()
         );
         assert!(

--- a/src/traits/bit_vec_ops.rs
+++ b/src/traits/bit_vec_ops.rs
@@ -697,11 +697,15 @@ pub trait AtomicBitVecOps<A: PrimitiveAtomicUnsigned<Value: Word>>: AsRef<[A]> +
             .iter()
             .for_each(|x| x.store(word_value, ordering));
         if residual != 0 {
+            // Use RMW operations: a plain load+store pair would lose a
+            // concurrent update to the residual word and reject
+            // store-invalid orderings such as Release for the load.
             let mask = (A::Value::ONE << residual) - A::Value::ONE;
-            bits[full_words].store(
-                (bits[full_words].load(ordering) & !mask) | (word_value & mask),
-                ordering,
-            );
+            if value {
+                bits[full_words].fetch_or(mask, ordering);
+            } else {
+                bits[full_words].fetch_and(!mask, ordering);
+            }
         }
     }
 
@@ -726,11 +730,14 @@ pub trait AtomicBitVecOps<A: PrimitiveAtomicUnsigned<Value: Word>>: AsRef<[A]> +
             .with_len(crate::RAYON_MIN_LEN)
             .for_each(|x| x.store(word_value, ordering));
         if residual != 0 {
+            // See `fill`: RMW keeps the residual update atomic and
+            // ordering-agnostic.
             let mask = (A::Value::ONE << residual) - A::Value::ONE;
-            bits[full_words].store(
-                (bits[full_words].load(ordering) & !mask) | (word_value & mask),
-                ordering,
-            );
+            if value {
+                bits[full_words].fetch_or(mask, ordering);
+            } else {
+                bits[full_words].fetch_and(!mask, ordering);
+            }
         }
     }
 
@@ -758,9 +765,10 @@ pub trait AtomicBitVecOps<A: PrimitiveAtomicUnsigned<Value: Word>>: AsRef<[A]> +
             .iter()
             .for_each(|x| _ = x.fetch_xor(!A::Value::ZERO, ordering));
         if residual != 0 {
+            // Use fetch_xor like the full words: a load+store pair would lose
+            // a concurrent update and reject orderings such as Release.
             let mask = (A::Value::ONE << residual) - A::Value::ONE;
-            let last_word = bits[full_words].load(ordering);
-            bits[full_words].store((last_word & !mask) | (!last_word & mask), ordering);
+            bits[full_words].fetch_xor(mask, ordering);
         }
     }
 
@@ -779,9 +787,10 @@ pub trait AtomicBitVecOps<A: PrimitiveAtomicUnsigned<Value: Word>>: AsRef<[A]> +
             .with_len(crate::RAYON_MIN_LEN)
             .for_each(|x| _ = x.fetch_xor(!A::Value::ZERO, ordering));
         if residual != 0 {
+            // See `flip`: RMW keeps the residual update atomic and
+            // ordering-agnostic.
             let mask = (A::Value::ONE << residual) - A::Value::ONE;
-            let last_word = bits[full_words].load(ordering);
-            bits[full_words].store((last_word & !mask) | (!last_word & mask), ordering);
+            bits[full_words].fetch_xor(mask, ordering);
         }
     }
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -37,12 +37,46 @@ pub use bit_vec_ops::*;
 
 /// Error returned by [`TryIntoUnaligned::try_into_unaligned`] when the
 /// bit width does not satisfy the constraints for unaligned reads.
-#[derive(Debug)]
-pub struct UnalignedConversionError(pub String);
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnalignedConversionError {
+    /// The bit width does not satisfy the constraints for single unaligned
+    /// reads on a `word_bits`-bit word (it must be at most `word_bits - 6`,
+    /// exactly `word_bits - 4`, or exactly `word_bits`).
+    InvalidBitWidth { bit_width: usize, word_bits: u32 },
+    /// The bit width does not satisfy the constraints for arbitrary-position
+    /// unaligned reads on a `word_bits`-bit word (it must be at most
+    /// `word_bits - 7`).
+    InvalidPosition { bit_width: usize, word_bits: u32 },
+    /// A collection contains one or more values whose bit widths do not satisfy
+    /// the constraints for unaligned reads.
+    MixedBitWidths,
+}
 
 impl std::fmt::Display for UnalignedConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        match *self {
+            Self::InvalidBitWidth {
+                bit_width,
+                word_bits,
+            } => write!(
+                f,
+                "bit width {bit_width} does not satisfy the constraints for unaligned reads on a {word_bits}-bit word (must be <= {}, == {}, or == {word_bits})",
+                word_bits.saturating_sub(6),
+                word_bits.saturating_sub(4),
+            ),
+            Self::InvalidPosition {
+                bit_width,
+                word_bits,
+            } => write!(
+                f,
+                "bit width {bit_width} does not satisfy the constraints for arbitrary-position unaligned reads on a {word_bits}-bit word (must be <= {})",
+                word_bits.saturating_sub(7),
+            ),
+            Self::MixedBitWidths => f.write_str(
+                "a collection contains values whose bit widths do not satisfy the constraints for unaligned reads",
+            ),
+        }
     }
 }
 

--- a/src/traits/rank_sel.rs
+++ b/src/traits/rank_sel.rs
@@ -387,11 +387,12 @@ pub trait SelectHinted {
     /// # Safety
     ///
     /// `rank` must be between zero (included) and the number of ones
-    /// in the underlying bit vector (excluded). `hint_pos` must be between 0
-    /// (included) and the [length of the underlying bit vector] (included), and
-    /// must be the position of a one in the underlying bit vector. `hint_rank`
-    /// must be the number of ones in the underlying bit vector before
-    /// `hint_pos`, and must be less than or equal to `rank`.
+    /// in the underlying bit vector (excluded). `hint_pos` must be at most the
+    /// position of the one of rank `rank`; in particular it must be strictly
+    /// less than the [length of the underlying bit vector]. It need *not*
+    /// itself be the position of a one. `hint_rank` must be the number of ones
+    /// in the underlying bit vector strictly before `hint_pos` (hence at most
+    /// `rank`).
     ///
     /// [length of the underlying bit vector]: BitLength::len
     unsafe fn select_hinted<const WORDS_PER_SUBBLOCK: usize>(
@@ -453,11 +454,12 @@ pub trait SelectZeroHinted {
     ///
     /// # Safety
     /// `rank` must be between zero (included) and the number of zeros in the
-    /// underlying bit vector (excluded). `hint_pos` must be between 0 (included)
-    /// and the [length of the underlying bit vector] (included), and must be the
-    /// position of a zero in the underlying bit vector. `hint_rank` must be the
-    /// number of zeros in the underlying bit vector before `hint_pos`, and must
-    /// be less than or equal to `rank`.
+    /// underlying bit vector (excluded). `hint_pos` must be at most the
+    /// position of the zero of rank `rank`; in particular it must be strictly
+    /// less than the [length of the underlying bit vector]. It need *not*
+    /// itself be the position of a zero. `hint_rank` must be the number of
+    /// zeros in the underlying bit vector strictly before `hint_pos` (hence at
+    /// most `rank`).
     ///
     /// [length of the underlying bit vector]: BitLength::len
     unsafe fn select_zero_hinted<const WORDS_PER_SUBBLOCK: usize>(

--- a/src/utils/fair_chunks.rs
+++ b/src/utils/fair_chunks.rs
@@ -207,6 +207,15 @@ impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> Iterator for FairC
         self.curr_pos = next_pos;
         Some(res)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.target_weight == 0 || self.curr_pos == self.num_weights {
+            return (0, Some(0));
+        }
+        // Each chunk covers at least one position, so at least one and at
+        // most `num_weights - curr_pos` chunks remain.
+        (1, Some(self.num_weights - self.curr_pos))
+    }
 }
 
 impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> FusedIterator for FairChunks<I> {}

--- a/src/utils/fair_chunks.rs
+++ b/src/utils/fair_chunks.rs
@@ -182,17 +182,30 @@ impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> Iterator for FairC
             return None;
         }
 
-        let target = self.current_weight + self.target_weight;
-        Some(if target > self.max_weight {
-            self.target_weight = 0;
-            self.curr_pos..self.num_weights
-        } else {
-            let (next_pos, next_weight) = unsafe { self.cwf.succ_unchecked::<false>(&target) };
-            self.current_weight = next_weight;
-            let res = self.curr_pos..next_pos;
-            self.curr_pos = next_pos;
-            res
-        })
+        // Use checked arithmetic: with `overflow-checks = false` the sum could
+        // wrap below the `> max_weight` guard on u64-scale weights, breaking the
+        // `succ_unchecked` precondition.
+        let target = match self.current_weight.checked_add(self.target_weight) {
+            Some(target) if target <= self.max_weight => target,
+            _ => {
+                // Past the last boundary (or overflow): emit the final chunk if
+                // any positions remain, then stop. Never emit an empty chunk.
+                self.target_weight = 0;
+                return if self.curr_pos == self.num_weights {
+                    None
+                } else {
+                    Some(self.curr_pos..self.num_weights)
+                };
+            }
+        };
+
+        // SAFETY: `target <= self.max_weight`, the largest cumulative weight, so
+        // a successor is guaranteed to exist.
+        let (next_pos, next_weight) = unsafe { self.cwf.succ_unchecked::<false>(&target) };
+        self.current_weight = next_weight;
+        let res = self.curr_pos..next_pos;
+        self.curr_pos = next_pos;
+        Some(res)
     }
 }
 

--- a/src/utils/fair_chunks.rs
+++ b/src/utils/fair_chunks.rs
@@ -70,7 +70,9 @@ use crate::traits::{IndexedSeq, SuccUnchecked};
 /// let mut efb = EliasFanoBuilder::new(cwf.len(), last_cwf);
 /// efb.extend(cwf);
 /// let ef = efb.build_with_dict();
-/// let chunks = FairChunks::new_with(50, &ef, weights.len(), last_cwf);
+/// // SAFETY: cwf is nondecreasing, weights.len() is one less than cwf.len(),
+/// // and last_cwf is the last element of cwf.
+/// let chunks = unsafe { FairChunks::new_with(50, &ef, weights.len(), last_cwf) };
 /// assert_eq!(
 ///     chunks.collect::<Vec<_>>(),
 ///     vec![
@@ -111,7 +113,8 @@ pub struct FairChunks<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> {
 }
 
 impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> FairChunks<I> {
-    /// Creates a fair chunk iterator using a structure supporting [`SuccUnchecked`].
+    /// Creates a fair chunk iterator using a structure supporting
+    /// [`SuccUnchecked`].
     ///
     /// # Arguments
     ///
@@ -123,9 +126,20 @@ impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> FairChunks<I> {
     ///
     /// * `max_weight` - The last element of the cumulative weight function.
     ///
+    /// # Safety
+    ///
+    /// `cwf` must be nondecreasing, `max_weight` must equal its last element,
+    /// and `num_weights` must be the number of weights, that is, one less than
+    /// the length of `cwf` (which starts with a leading zero). [`next`]
+    /// performs unchecked successor queries on `cwf` for targets it proves to
+    /// be at most `max_weight`; if `max_weight` overstates the last element, a
+    /// successor query is made for a value with no successor, which is
+    /// undefined behavior.
+    ///
+    /// [`next`]: Iterator::next
     /// [unchecked successor queries]: crate::traits::SuccUnchecked
     #[must_use]
-    pub fn new_with(target_weight: u64, cwf: I, num_weights: usize, max_weight: u64) -> Self {
+    pub unsafe fn new_with(target_weight: u64, cwf: I, num_weights: usize, max_weight: u64) -> Self {
         Self {
             target_weight,
             cwf,

--- a/src/utils/fair_chunks.rs
+++ b/src/utils/fair_chunks.rs
@@ -139,7 +139,12 @@ impl<I: for<'a> SuccUnchecked<Input = u64, Output<'a> = u64>> FairChunks<I> {
     /// [`next`]: Iterator::next
     /// [unchecked successor queries]: crate::traits::SuccUnchecked
     #[must_use]
-    pub unsafe fn new_with(target_weight: u64, cwf: I, num_weights: usize, max_weight: u64) -> Self {
+    pub unsafe fn new_with(
+        target_weight: u64,
+        cwf: I,
+        num_weights: usize,
+        max_weight: u64,
+    ) -> Self {
         Self {
             target_weight,
             cwf,

--- a/src/utils/mod2_sys.rs
+++ b/src/utils/mod2_sys.rs
@@ -194,7 +194,12 @@ impl<W: Word> Modulo2System<W> {
         }
         let mut scratch: Vec<u32> = Vec::new();
         'main: for i in 0..equations.len() - 1 {
-            ensure!(!equations[i].vars.is_empty());
+            // A pivot row reduced to `[] = c`: unsolvable if c != 0, otherwise
+            // a redundant identity that takes no part in elimination.
+            if equations[i].vars.is_empty() {
+                ensure!(!equations[i].is_unsolvable(), "System is unsolvable");
+                continue;
+            }
             for j in i + 1..equations.len() {
                 let (left, right) = equations.split_at_mut(j);
                 let eq_i = &mut left[i];
@@ -487,6 +492,37 @@ mod tests {
 
         let solution = system.gaussian_elimination();
         assert!(solution.is_err());
+    }
+
+    #[test]
+    fn test_gaussian_elimination_leading_identity_row() {
+        let mut system = Modulo2System::<usize>::new(1);
+        // SAFETY: the empty variable list is sorted and contains no
+        // out-of-bounds variable indices.
+        let eq0 = unsafe { Modulo2Equation::from_parts(vec![], 0_usize) };
+        system.push(eq0);
+        // SAFETY: variable 0 is in bounds for this one-variable system, and
+        // the variable list is sorted.
+        let eq1 = unsafe { Modulo2Equation::from_parts(vec![0], 1_usize) };
+        system.push(eq1);
+
+        let solution = system.gaussian_elimination().unwrap();
+        assert!(system.check(&solution));
+    }
+
+    #[test]
+    fn test_gaussian_elimination_leading_unsolvable_row() {
+        let mut system = Modulo2System::<usize>::new(1);
+        // SAFETY: the empty variable list is sorted and contains no
+        // out-of-bounds variable indices.
+        let eq0 = unsafe { Modulo2Equation::from_parts(vec![], 1_usize) };
+        system.push(eq0);
+        // SAFETY: variable 0 is in bounds for this one-variable system, and
+        // the variable list is sorted.
+        let eq1 = unsafe { Modulo2Equation::from_parts(vec![0], 1_usize) };
+        system.push(eq1);
+
+        assert!(system.gaussian_elimination().is_err());
     }
 
     #[test]

--- a/src/utils/mod2_sys.rs
+++ b/src/utils/mod2_sys.rs
@@ -200,6 +200,14 @@ impl<W: Word> Modulo2System<W> {
                 let eq_i = &mut left[i];
                 let eq_j = &right[0];
 
+                // A later row reduced to `[] = c`: unsolvable if c != 0, else a
+                // redundant identity to skip. Without this, `eq_j.vars[0]` below
+                // would panic on the empty variable list.
+                if eq_j.vars.is_empty() {
+                    ensure!(!eq_j.is_unsolvable(), "System is unsolvable");
+                    continue;
+                }
+
                 let first_var_j = eq_j.vars[0];
 
                 if eq_i.vars[0] == first_var_j {
@@ -223,6 +231,12 @@ impl<W: Word> Modulo2System<W> {
     /// Solves the system using Gaussian elimination.
     pub fn gaussian_elimination(&mut self) -> Result<Vec<W>> {
         self.echelon_form()?;
+        // An equation reduced to `[] = c` with c != 0 has no solution; the
+        // back-substitution below would index `eq.vars[0]` on an empty variable
+        // list. `echelon_form` only checks emptiness for rows before the last.
+        for eq in &self.equations {
+            ensure!(!eq.is_unsolvable(), "System is unsolvable");
+        }
         let mut solution = vec![W::ZERO; self.num_vars];
         self.equations
             .iter()
@@ -456,6 +470,22 @@ mod tests {
         let eq1 = unsafe { Modulo2Equation::from_parts(vec![0], 1_usize) };
         system.push(eq1);
         let solution = system.lazy_gaussian_elimination();
+        assert!(solution.is_err());
+    }
+
+    #[test]
+    fn test_gaussian_elimination_last_unsolvable_equation() {
+        let mut system = Modulo2System::<usize>::new(1);
+        // SAFETY: variable 0 is in bounds for this one-variable system, and
+        // the variable list is sorted.
+        let eq0 = unsafe { Modulo2Equation::from_parts(vec![0], 0_usize) };
+        system.push(eq0);
+        // SAFETY: the empty variable list is sorted and contains no
+        // out-of-bounds variable indices.
+        let eq1 = unsafe { Modulo2Equation::from_parts(vec![], 1_usize) };
+        system.push(eq1);
+
+        let solution = system.gaussian_elimination();
         assert!(solution.is_err());
     }
 

--- a/src/utils/select_in_word.rs
+++ b/src/utils/select_in_word.rs
@@ -18,8 +18,19 @@
 /// assert_eq!(0x8000_0000_8000_0000_u64.select_in_word(1), 63);
 /// ```
 pub trait SelectInWord: core::ops::Not<Output = Self> + Sized + Copy {
+    /// Returns the position of the one of the given `rank` (0-based).
+    ///
+    /// `rank` must be strictly less than the number of ones in the word;
+    /// otherwise the result is unspecified and may panic (some
+    /// implementations index a lookup table out of bounds, others return a
+    /// position at or beyond the word width).
     fn select_in_word(&self, rank: usize) -> usize;
 
+    /// Returns the position of the zero of the given `rank` (0-based).
+    ///
+    /// `rank` must be strictly less than the number of zeros in the word;
+    /// otherwise the result is unspecified and may panic (see
+    /// [`select_in_word`](Self::select_in_word)).
     #[inline(always)]
     fn select_zero_in_word(&self, rank: usize) -> usize {
         (!*self).select_in_word(rank)

--- a/src/utils/sig_store.rs
+++ b/src/utils/sig_store.rs
@@ -1234,22 +1234,24 @@ where
 
     fn iter(&mut self) -> Box<dyn Iterator<Item = Arc<Vec<SigVal<S, V>>>> + Send + Sync + '_> {
         let filter = &self.filter;
-        let inner_shards: Vec<_> = self.inner.iter().collect();
+        // Filter one shard at a time, lazily, so the whole store is never
+        // materialized in RAM at once.
         Box::new(
-            inner_shards
-                .into_iter()
-                .map(move |shard| {
-                    let filtered: Vec<_> = shard.iter().filter(|sv| filter(sv)).copied().collect();
-                    Arc::new(filtered)
-                })
-                .collect::<Vec<_>>()
-                .into_iter(),
+            self.inner.iter().map(move |shard| {
+                Arc::new(shard.iter().filter(|sv| filter(sv)).copied().collect())
+            }),
         )
     }
 
     fn drain(&mut self) -> Box<dyn Iterator<Item = Arc<Vec<SigVal<S, V>>>> + Send + Sync + '_> {
-        // FilteredShardStore always re-filters, so drain == iter.
-        self.iter()
+        let filter = &self.filter;
+        // Same filtering as `iter`, but drains the inner store so each shard's
+        // memory is released as it is consumed.
+        Box::new(
+            self.inner.drain().map(move |shard| {
+                Arc::new(shard.iter().filter(|sv| filter(sv)).copied().collect())
+            }),
+        )
     }
 }
 
@@ -1381,5 +1383,98 @@ mod tests {
             [rand.random(), rand.random()]
         })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod filtered_lazy_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    type SV = SigVal<[u64; 2], u8>;
+
+    /// An inner iterator that counts how many shards have been pulled.
+    struct Counting {
+        inner: std::vec::IntoIter<Arc<Vec<SV>>>,
+        counter: Arc<AtomicUsize>,
+    }
+    impl Iterator for Counting {
+        type Item = Arc<Vec<SV>>;
+        fn next(&mut self) -> Option<Self::Item> {
+            let next = self.inner.next();
+            if next.is_some() {
+                self.counter.fetch_add(1, Ordering::Relaxed);
+            }
+            next
+        }
+    }
+
+    /// A minimal in-memory [`ShardStore`] with separate counters for the
+    /// `iter` and `drain` paths.
+    struct Fake {
+        shards: Vec<Arc<Vec<SV>>>,
+        iter_pulls: Arc<AtomicUsize>,
+        drain_pulls: Arc<AtomicUsize>,
+    }
+    impl ShardStore<[u64; 2], u8> for Fake {
+        fn shard_sizes(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+            let sizes: Vec<usize> = self.shards.iter().map(|s| s.len()).collect();
+            Box::new(sizes.into_iter())
+        }
+        fn set_shard_high_bits(&mut self, _new_bits: u32) {}
+        fn max_shard_high_bits(&self) -> u32 {
+            0
+        }
+        fn iter(&mut self) -> Box<dyn Iterator<Item = Arc<Vec<SV>>> + Send + Sync + '_> {
+            Box::new(Counting {
+                inner: self.shards.clone().into_iter(),
+                counter: self.iter_pulls.clone(),
+            })
+        }
+        fn drain(&mut self) -> Box<dyn Iterator<Item = Arc<Vec<SV>>> + Send + Sync + '_> {
+            Box::new(Counting {
+                inner: std::mem::take(&mut self.shards).into_iter(),
+                counter: self.drain_pulls.clone(),
+            })
+        }
+    }
+
+    #[test]
+    fn filtered_iter_is_lazy_and_drain_uses_inner_drain() {
+        let sv = |s: u64, v: u8| SigVal {
+            sig: [s, 0],
+            val: v,
+        };
+        let shards = vec![Arc::new(vec![sv(1, 0), sv(2, 1)]), Arc::new(vec![sv(3, 0)])];
+        let iter_pulls = Arc::new(AtomicUsize::new(0));
+        let drain_pulls = Arc::new(AtomicUsize::new(0));
+        let mut fake = Fake {
+            shards,
+            iter_pulls: iter_pulls.clone(),
+            drain_pulls: drain_pulls.clone(),
+        };
+        let mut fs = FilteredShardStore::new(&mut fake, 0, |sv: &SV| sv.val == 0, vec![1, 1]);
+
+        {
+            let mut it = fs.iter();
+            // Building the iterator must not pull any inner shard.
+            assert_eq!(iter_pulls.load(Ordering::Relaxed), 0);
+            let first = it.next().unwrap();
+            // Exactly one inner shard was pulled, filtered to val == 0.
+            assert_eq!(iter_pulls.load(Ordering::Relaxed), 1);
+            assert_eq!(first.len(), 1);
+            assert_eq!(first[0].sig, [1, 0]);
+        }
+
+        // `drain` is lazy too and goes through the inner `drain` path.
+        let mut drain_it = fs.drain();
+        assert_eq!(drain_pulls.load(Ordering::Relaxed), 0);
+        drain_it.next().unwrap();
+        assert_eq!(drain_pulls.load(Ordering::Relaxed), 1);
+        let rest: Vec<_> = drain_it.collect();
+        assert_eq!(drain_pulls.load(Ordering::Relaxed), 2);
+        // The `iter` path was not used by `drain`.
+        assert_eq!(iter_pulls.load(Ordering::Relaxed), 1);
+        assert_eq!(rest.len(), 1);
     }
 }

--- a/src/utils/sig_store.rs
+++ b/src/utils/sig_store.rs
@@ -387,7 +387,10 @@ pub trait SigStore<S: Sig + BinSafe, V: BinSafe> {
     /// # Panics
     ///
     /// It must hold that `shard_high_bits` is at most
-    /// [`max_shard_high_bits`] or this method will panic.
+    /// [`max_shard_high_bits`] or this method will panic. For an offline
+    /// (file-backed) store, iterating the resulting shard store also panics
+    /// if a temp-file read or seek fails (a disk error or a truncated
+    /// temporary file); such a mid-build I/O failure is not recoverable.
     ///
     /// [`max_shard_high_bits`]: SigStore::max_shard_high_bits
     fn into_shard_store(self, shard_high_bits: u32) -> Result<Self::ShardStore>;
@@ -962,8 +965,12 @@ impl<
                 assert!(post.is_empty());
                 for i in self.next_bucket..self.next_bucket + to_aggr {
                     let bytes = store.buf_sizes[i] * core::mem::size_of::<SigVal<S, V>>();
-                    store.buckets[i].seek(SeekFrom::Start(0)).unwrap();
-                    store.buckets[i].read_exact(&mut buf[..bytes]).unwrap();
+                    store.buckets[i]
+                        .seek(SeekFrom::Start(0))
+                        .expect("offline signature store: temp-file seek failed");
+                    store.buckets[i]
+                        .read_exact(&mut buf[..bytes])
+                        .expect("offline signature store: temp-file read failed (disk error or truncation)");
                     if !self.borrowed {
                         let _ = store.buckets[i].get_mut().set_len(0);
                     }
@@ -1003,7 +1010,7 @@ impl<
                 let shard_mask = (1 << store.shard_high_bits) - 1;
                 store.buckets[self.next_bucket]
                     .seek(SeekFrom::Start(0))
-                    .unwrap();
+                    .expect("offline signature store: temp-file seek failed");
 
                 while len > 0 {
                     let to_read = buf_size.min(len);
@@ -1014,7 +1021,9 @@ impl<
                     debug_assert!(pre.is_empty());
                     debug_assert!(after.is_empty());
 
-                    store.buckets[self.next_bucket].read_exact(buf).unwrap();
+                    store.buckets[self.next_bucket]
+                        .read_exact(buf)
+                        .expect("offline signature store: temp-file read failed (disk error or truncation)");
 
                     // We move each signature/value pair into its shard
                     for &v in &buffer {

--- a/src/utils/sig_store.rs
+++ b/src/utils/sig_store.rs
@@ -968,9 +968,9 @@ impl<
                     store.buckets[i]
                         .seek(SeekFrom::Start(0))
                         .expect("offline signature store: temp-file seek failed");
-                    store.buckets[i]
-                        .read_exact(&mut buf[..bytes])
-                        .expect("offline signature store: temp-file read failed (disk error or truncation)");
+                    store.buckets[i].read_exact(&mut buf[..bytes]).expect(
+                        "offline signature store: temp-file read failed (disk error or truncation)",
+                    );
                     if !self.borrowed {
                         let _ = store.buckets[i].get_mut().set_len(0);
                     }
@@ -1021,9 +1021,9 @@ impl<
                     debug_assert!(pre.is_empty());
                     debug_assert!(after.is_empty());
 
-                    store.buckets[self.next_bucket]
-                        .read_exact(buf)
-                        .expect("offline signature store: temp-file read failed (disk error or truncation)");
+                    store.buckets[self.next_bucket].read_exact(buf).expect(
+                        "offline signature store: temp-file read failed (disk error or truncation)",
+                    );
 
                     // We move each signature/value pair into its shard
                     for &v in &buffer {

--- a/src/utils/sig_store.rs
+++ b/src/utils/sig_store.rs
@@ -476,6 +476,11 @@ pub fn new_offline<S: BinSafe + Sig, V: BinSafe>(
     _expected_num_keys: Option<usize>,
 ) -> Result<SigStoreImpl<S, V, BufWriter<File>>> {
     let temp_dir = tempfile::TempDir::new()?;
+    anyhow::ensure!(
+        buckets_high_bits < usize::BITS && max_shard_high_bits < usize::BITS,
+        "high bit counts must be less than {} (got buckets {buckets_high_bits}, max shard {max_shard_high_bits})",
+        usize::BITS
+    );
     let mut writers = VecDeque::new();
     for i in 0..1 << buckets_high_bits {
         let file = File::options()
@@ -516,6 +521,11 @@ pub fn new_online<S: BinSafe + Sig, V: BinSafe>(
     expected_num_keys: Option<usize>,
 ) -> Result<SigStoreImpl<S, V, Vec<SigVal<S, V>>>> {
     let mut writers = VecDeque::new();
+    anyhow::ensure!(
+        buckets_high_bits < usize::BITS && max_shard_high_bits < usize::BITS,
+        "high bit counts must be less than {} (got buckets {buckets_high_bits}, max shard {max_shard_high_bits})",
+        usize::BITS
+    );
     let initial_capacity = expected_num_keys
         .map(|n| (n.div_ceil(1 << buckets_high_bits) as f64 * 1.05) as usize)
         .unwrap_or(0);
@@ -1281,6 +1291,18 @@ impl<S: Sig, V: BinSafe> ShardStore<S, V> for Box<dyn ShardStore<S, V> + Send + 
 mod tests {
     use super::*;
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
+
+    #[test]
+    fn test_high_bits_validation() {
+        // High-bit counts at or above the word width would overflow the
+        // `1 << bits` allocations and masks; they must be rejected.
+        assert!(new_offline::<[u64; 1], u64>(usize::BITS, 8, None).is_err());
+        assert!(new_offline::<[u64; 1], u64>(8, usize::BITS, None).is_err());
+        assert!(new_online::<[u64; 1], u64>(usize::BITS, 8, None).is_err());
+        assert!(new_online::<[u64; 1], u64>(8, usize::BITS, None).is_err());
+        // Valid parameters still succeed.
+        assert!(new_online::<[u64; 1], u64>(4, 8, None).is_ok());
+    }
 
     fn _test_sig_store<S: BinSafe + Sig + Send + Sync>(
         mut sig_store: impl SigStore<S, u64>,

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -1040,3 +1040,98 @@ fn test_unaligned_conversion_error() {
     );
     assert!(err.to_string().contains(&format!("bit width {bad}")));
 }
+
+#[test]
+fn test_iter_full_width() -> Result<()> {
+    let mut v = BitFieldVec::<Vec<u64>>::new(64, 0);
+    for x in [u64::MAX, 42, 0, 7] {
+        v.push(x);
+    }
+    assert_eq!(v.iter().collect::<Vec<_>>(), vec![u64::MAX, 42, 0, 7]);
+    assert_eq!(v.iter_from(1).collect::<Vec<_>>(), vec![42, 0, 7]);
+    Ok(())
+}
+
+#[test]
+fn test_iter_back_full_width() -> Result<()> {
+    use sux::traits::iter::{IntoUncheckedBackIterator, UncheckedIterator};
+    for (width, values) in [
+        (64usize, vec![u64::MAX, 42, 0, 7]),
+        (33, vec![1u64 << 32, 42, 0, (1 << 33) - 1]),
+        (1, vec![1u64, 0, 1, 1]),
+    ] {
+        let mut v = BitFieldVec::<Vec<u64>>::new(width, 0);
+        for &x in &values {
+            v.push(x);
+        }
+        let mut it = (&v).into_unchecked_iter_back();
+        let mut back = Vec::new();
+        for _ in 0..values.len() {
+            // SAFETY: we pull exactly len elements from an end-positioned
+            // backward iterator, so every call has a preceding element.
+            back.push(unsafe { it.next_unchecked() });
+        }
+        let expected: Vec<_> = values.iter().rev().copied().collect();
+        assert_eq!(back, expected, "width {width}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_apply_in_place_unchecked_full_width() -> Result<()> {
+    let mut v = BitFieldVec::<Vec<u64>>::new(64, 0);
+    for x in [u64::MAX, 42, 7] {
+        v.push(x);
+    }
+    let mut seen = Vec::new();
+    // SAFETY: the closure returns values fitting the (full) bit width.
+    unsafe {
+        v.apply_in_place_unchecked(|x| {
+            seen.push(x);
+            x.wrapping_add(1)
+        })
+    };
+    assert_eq!(seen, vec![u64::MAX, 42, 7]);
+    assert_eq!(v.iter().collect::<Vec<_>>(), vec![0, 43, 8]);
+    Ok(())
+}
+
+#[test]
+fn test_apply_in_place_unchecked_logical_only() -> Result<()> {
+    for width in [3usize, 5, 8, 64] {
+        // Backend with sentinel words beyond the words containing elements,
+        // and dirty tail bits in the last logical word.
+        let len = 5;
+        let words = (len * width).div_ceil(64);
+        let mut backend = vec![0u64; words + 2];
+        backend[words] = 0xDEAD_BEEF_DEAD_BEEF;
+        backend[words + 1] = 0xCAFE_BABE_CAFE_BABE;
+        let tail_bits = (len * width) % 64;
+        if tail_bits != 0 {
+            backend[words - 1] = u64::MAX << tail_bits;
+        }
+        let mut v = BitFieldVec::wrap(backend, width, len);
+        let mut count = 0usize;
+        // SAFETY: the closure returns 1, which fits every tested width.
+        unsafe {
+            v.apply_in_place_unchecked(|x| {
+                count += 1;
+                assert_eq!(x, 0, "width {width}: called on a non-element");
+                1
+            })
+        };
+        assert_eq!(count, len, "width {width}");
+        assert_eq!(v.iter().collect::<Vec<_>>(), vec![1; len], "width {width}");
+        let (backend, _, _) = v.into_raw_parts();
+        assert_eq!(backend[words], 0xDEAD_BEEF_DEAD_BEEF, "width {width}");
+        assert_eq!(backend[words + 1], 0xCAFE_BABE_CAFE_BABE, "width {width}");
+        if tail_bits != 0 {
+            assert_eq!(
+                backend[words - 1] & (u64::MAX << tail_bits),
+                u64::MAX << tail_bits,
+                "width {width}: tail bits must be preserved"
+            );
+        }
+    }
+    Ok(())
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -1160,3 +1160,13 @@ fn test_apply_in_place_inputs() -> Result<()> {
     assert_eq!(v.iter().collect::<Vec<_>>(), vec![6, 5, 4]);
     Ok(())
 }
+
+#[test]
+fn test_chunks_mut_size_hint() -> Result<()> {
+    let mut v = BitFieldVec::<Vec<u64>>::new(64, 10);
+    let chunks = v.try_chunks_mut(3).map_err(anyhow::Error::from)?;
+    assert_eq!(chunks.size_hint(), (4, Some(4)));
+    assert_eq!(chunks.len(), 4);
+    assert_eq!(chunks.count(), 4);
+    Ok(())
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -896,3 +896,72 @@ fn test_epserde() {
         assert_eq!(bfv.get_value(i), bfv2.get_value(i));
     }
 }
+
+fn assert_zero_width_values<W: Word>(b: &BitFieldVec<Vec<W>>, len: usize) {
+    assert_eq!(b.bit_width(), 0);
+    assert_eq!(b.len(), len);
+    for i in 0..len {
+        assert_eq!(b.index_value(i), W::ZERO);
+    }
+
+    let (backend, bit_width, raw_len) = b.clone().into_raw_parts();
+    assert!(!backend.is_empty());
+    assert_eq!(bit_width, 0);
+    assert_eq!(raw_len, len);
+}
+
+#[test]
+fn test_zero_width_with_capacity_push() {
+    for capacity in [1, 8] {
+        let mut b = BitFieldVec::<Vec<usize>>::with_capacity(0, capacity);
+        assert_zero_width_values(&b, 0);
+
+        for len in 1..=capacity {
+            b.push(0);
+            assert_zero_width_values(&b, len);
+        }
+    }
+}
+
+#[test]
+fn test_zero_width_new() {
+    for len in [0, 1, 5] {
+        let b = BitFieldVec::<Vec<u64>>::new(0, len);
+        assert_zero_width_values(&b, len);
+    }
+}
+
+#[test]
+fn test_zero_width_resize_grow() {
+    let mut b = BitFieldVec::<Vec<u16>>::with_capacity(0, 8);
+    assert_zero_width_values(&b, 0);
+
+    for len in [1, 5, 8] {
+        b.resize(len, 0);
+        assert_zero_width_values(&b, len);
+    }
+}
+
+#[test]
+fn test_zero_width_wrap_single_word() {
+    let b = BitFieldVec::<Vec<usize>>::wrap(vec![0usize], 0, 3);
+    assert_zero_width_values(&b, 3);
+}
+
+#[test]
+#[should_panic]
+fn test_zero_width_wrap_empty_nonzero_len_panics() {
+    let _ = BitFieldVec::<Vec<usize>>::wrap(Vec::new(), 0, 5);
+}
+
+#[test]
+fn test_zero_width_macro_forms() {
+    let b = bit_field_vec![0];
+    assert_zero_width_values(&b, 0);
+
+    let b = bit_field_vec![0 => 0; 5];
+    assert_zero_width_values(&b, 5);
+
+    let b = bit_field_vec![0; 0, 0, 0];
+    assert_zero_width_values(&b, 3);
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -1021,3 +1021,22 @@ fn test_set_atomic_accepts_store_orderings() {
         assert_eq!(v.get_atomic(15, Ordering::Relaxed), 42);
     }
 }
+
+#[test]
+fn test_unaligned_conversion_error() {
+    use sux::traits::{TryIntoUnaligned, UnalignedConversionError};
+    let word_bits = usize::BITS;
+    // W::BITS - 5 is a valid field width but not a valid unaligned width
+    // (not <= W-6, not == W-4, not == W).
+    let bad = usize::try_from(word_bits - 5).unwrap();
+    let v: BitFieldVec<Box<[usize]>> = BitFieldVec::<Vec<usize>>::new(bad, 4).into();
+    let err = v.try_into_unaligned().unwrap_err();
+    assert_eq!(
+        err,
+        UnalignedConversionError::InvalidBitWidth {
+            bit_width: bad,
+            word_bits,
+        }
+    );
+    assert!(err.to_string().contains(&format!("bit width {bad}")));
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -965,3 +965,35 @@ fn test_zero_width_macro_forms() {
     let b = bit_field_vec![0; 0, 0, 0];
     assert_zero_width_values(&b, 3);
 }
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic(expected = "overflows usize")]
+fn test_new_panics_on_bit_len_overflow() {
+    let _ = BitFieldVec::<Vec<u64>>::new(64, usize::MAX / 64 + 2);
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic(expected = "overflows usize")]
+fn test_with_capacity_panics_on_bit_len_overflow() {
+    let _ = BitFieldVec::<Vec<u64>>::with_capacity(64, usize::MAX / 64 + 2);
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic(expected = "overflows usize")]
+fn test_zero_width_push_panics_on_len_overflow() {
+    let mut v = BitFieldVec::<Vec<usize>>::wrap(vec![0usize], 0, usize::MAX);
+    v.push(0);
+}
+
+#[test]
+fn test_zero_width_copy_is_noop() {
+    let src = BitFieldVec::<Vec<usize>>::new(0, 4);
+    let mut dst = BitFieldVec::<Vec<usize>>::new(0, 4);
+
+    SliceByValueMut::copy(&src, 1, &mut dst, 0, 3);
+
+    assert_zero_width_values(&dst, 4);
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -997,3 +997,27 @@ fn test_zero_width_copy_is_noop() {
 
     assert_zero_width_values(&dst, 4);
 }
+
+#[test]
+fn test_set_atomic_accepts_store_orderings() {
+    use std::sync::atomic::AtomicUsize;
+    // With bit width 7 over 64-bit words, index 9 straddles a word boundary
+    // (bit 63), exercising the cross-word CAS path as well as the aligned one.
+    // set_atomic must accept every valid store/RMW ordering, including Release
+    // and AcqRel (which are illegal for the internal load / CAS-failure slot and
+    // previously panicked). Reads use a valid load ordering.
+    for order in [
+        Ordering::Relaxed,
+        Ordering::Release,
+        Ordering::AcqRel,
+        Ordering::SeqCst,
+    ] {
+        let v = AtomicBitFieldVec::<Vec<AtomicUsize>>::new(7, 16);
+        v.set_atomic(0, 5, order);
+        v.set_atomic(9, 100, order);
+        v.set_atomic(15, 42, order);
+        assert_eq!(v.get_atomic(0, Ordering::Relaxed), 5);
+        assert_eq!(v.get_atomic(9, Ordering::Relaxed), 100);
+        assert_eq!(v.get_atomic(15, Ordering::Relaxed), 42);
+    }
+}

--- a/tests/test_bit_field_vec.rs
+++ b/tests/test_bit_field_vec.rs
@@ -1135,3 +1135,28 @@ fn test_apply_in_place_unchecked_logical_only() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+#[should_panic(expected = "does not fit in 3 bits")]
+fn test_apply_in_place_oversized_panics() {
+    let mut v = BitFieldVec::<Vec<u64>>::new(3, 3);
+    // 0xFF does not fit in 3 bits: the safe method must panic like set_value,
+    // not spill into neighboring fields.
+    v.apply_in_place(|_| 0xFF);
+}
+
+#[test]
+fn test_apply_in_place_inputs() -> Result<()> {
+    let mut v = BitFieldVec::<Vec<u64>>::new(3, 3);
+    v.set_value(0, 1);
+    v.set_value(1, 2);
+    v.set_value(2, 3);
+    let mut seen = Vec::new();
+    v.apply_in_place(|x| {
+        seen.push(x);
+        7 - x
+    });
+    assert_eq!(seen, vec![1, 2, 3]);
+    assert_eq!(v.iter().collect::<Vec<_>>(), vec![6, 5, 4]);
+    Ok(())
+}

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -1203,3 +1203,30 @@ fn test_unaligned_get_bits_overflow() {
     // must reject it deterministically in both profiles.
     let _ = bv.get_value_unaligned(usize::MAX, 2);
 }
+
+#[test]
+fn test_bit_iter_size_hint() {
+    let mut bv = BitVec::<Vec<usize>>::new(100);
+    bv.set(1, true);
+    let mut iter = bv.iter();
+    assert_eq!(iter.size_hint(), (100, Some(100)));
+    assert_eq!(iter.len(), 100);
+    iter.next();
+    assert_eq!(iter.size_hint(), (99, Some(99)));
+
+    let abv = AtomicBitVec::<Vec<AtomicUsize>>::new(65);
+    let mut iter = abv.iter();
+    assert_eq!(iter.size_hint(), (65, Some(65)));
+    iter.next();
+    assert_eq!(iter.size_hint(), (64, Some(64)));
+}
+
+#[test]
+fn test_bit_vec_chunks_mut_size_hint() {
+    use value_traits::slices::SliceByValueMut;
+    let mut bv = BitVec::<Vec<usize>>::new(256);
+    let chunks = bv.try_chunks_mut(64).unwrap();
+    assert_eq!(chunks.size_hint(), (4, Some(4)));
+    assert_eq!(chunks.len(), 4);
+    assert_eq!(chunks.count(), 4);
+}

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -1180,3 +1180,17 @@ fn test_get_bits_panics_on_bit_range_end_overflow() {
     let bv: BitVec = BitVec::new(8);
     bv.get_bits(usize::MAX, 1);
 }
+
+#[test]
+#[should_panic(expected = "bit length overflows usize")]
+fn test_reserve_panics_on_len_overflow() {
+    let mut b = BitVec::<Vec<usize>>::new(1);
+    b.reserve(usize::MAX);
+}
+
+#[test]
+#[should_panic(expected = "bit length overflows usize")]
+fn test_reserve_exact_panics_on_len_overflow() {
+    let mut b = BitVec::<Vec<usize>>::new(1);
+    b.reserve_exact(usize::MAX);
+}

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -985,7 +985,7 @@ fn test_reserve() {
     assert!(b.capacity() >= 150);
 }
 
-/// Test get_value / get_value_unchecked / append_value with a given word type.
+/// Test get_bits / get_bits_unchecked / append_value with a given word type.
 macro_rules! test_value_ops_word_type {
     ($W:ty) => {{
         let bpw = <$W>::BITS as usize;
@@ -994,7 +994,7 @@ macro_rules! test_value_ops_word_type {
         {
             let mut bv: BitVec<Vec<$W>> = BitVec::new(0);
             bv.push(true);
-            assert_eq!(bv.get_value(0, 0), (0 as $W));
+            assert_eq!(bv.get_bits(0, 0), (0 as $W));
         }
 
         // width == W::BITS, word-aligned (bit_index == 0)
@@ -1003,8 +1003,8 @@ macro_rules! test_value_ops_word_type {
             let val: $W = !(0 as $W) / 3; // alternating bits
             bv.append_value(val, bpw);
             assert_eq!(bv.len(), bpw);
-            assert_eq!(bv.get_value(0, bpw), val);
-            assert_eq!(unsafe { bv.get_value_unchecked(0, bpw) }, val);
+            assert_eq!(bv.get_bits(0, bpw), val);
+            assert_eq!(unsafe { bv.get_bits_unchecked(0, bpw) }, val);
         }
 
         // width == W::BITS, not word-aligned (bit_index > 0, spans two words)
@@ -1018,12 +1018,12 @@ macro_rules! test_value_ops_word_type {
                 let val: $W = !(0 as $W) / 5; // known pattern
                 bv.append_value(val, bpw);
                 assert_eq!(
-                    bv.get_value(offset, bpw),
+                    bv.get_bits(offset, bpw),
                     val,
                     "width={bpw}, offset={offset}"
                 );
                 assert_eq!(
-                    unsafe { bv.get_value_unchecked(offset, bpw) },
+                    unsafe { bv.get_bits_unchecked(offset, bpw) },
                     val,
                     "width={bpw}, offset={offset}"
                 );
@@ -1046,7 +1046,7 @@ macro_rules! test_value_ops_word_type {
                     };
                     let expected = (val >> pos) & mask;
                     assert_eq!(
-                        bv.get_value(pos, width),
+                        bv.get_bits(pos, width),
                         expected,
                         "single-word: pos={pos}, width={width}"
                     );
@@ -1074,7 +1074,7 @@ macro_rules! test_value_ops_word_type {
                     };
                     let expected = ((val0 >> pos) | (val1 << (bpw - pos))) & mask;
                     assert_eq!(
-                        bv.get_value(pos, width),
+                        bv.get_bits(pos, width),
                         expected,
                         "spanning: pos={pos}, width={width}"
                     );
@@ -1105,7 +1105,7 @@ macro_rules! test_value_ops_word_type {
                     }
                     bv.append_value(val, width);
                     assert_eq!(
-                        bv.get_value(offset, width),
+                        bv.get_bits(offset, width),
                         val,
                         "append round-trip: width={width}, offset={offset}"
                     );
@@ -1119,12 +1119,12 @@ macro_rules! test_value_ops_word_type {
                 let mut bv: BitVec<Vec<$W>> = BitVec::new(0);
                 bv.append_value(!(0 as $W), width); // all bits set, but only `width` should survive
                 let mask = ((1 as $W) << width) - (1 as $W);
-                assert_eq!(bv.get_value(0, width), mask, "masking: width={width}");
+                assert_eq!(bv.get_bits(0, width), mask, "masking: width={width}");
             }
             // width == W::BITS: all bits survive
             let mut bv: BitVec<Vec<$W>> = BitVec::new(0);
             bv.append_value(!(0 as $W), bpw);
-            assert_eq!(bv.get_value(0, bpw), !(0 as $W));
+            assert_eq!(bv.get_bits(0, bpw), !(0 as $W));
         }
 
         // Multiple appends at sequential positions
@@ -1139,7 +1139,7 @@ macro_rules! test_value_ops_word_type {
             }
             for (i, &v) in vals.iter().enumerate() {
                 assert_eq!(
-                    bv.get_value(i * width, width),
+                    bv.get_bits(i * width, width),
                     v,
                     "sequential: i={i}, width={width}"
                 );
@@ -1176,7 +1176,7 @@ fn test_value_ops_usize() {
 #[cfg(target_pointer_width = "64")]
 #[test]
 #[should_panic(expected = "overflows usize")]
-fn test_get_value_panics_on_bit_range_end_overflow() {
+fn test_get_bits_panics_on_bit_range_end_overflow() {
     let bv: BitVec = BitVec::new(8);
-    bv.get_value(usize::MAX, 1);
+    bv.get_bits(usize::MAX, 1);
 }

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -955,13 +955,13 @@ fn test_append_dirty_last_word() {
     a.append_value(0xFFFFFFFFFFFFFFFF, 64);
     a.resize(50, false); // dirty last word 
     a.append_value(0, 64); // append to dirty last word
-    assert!(a[51] == false);
+    assert!(!a[51]);
 
     let mut a: BitVec = BitVec::new(0);
     a.append_value(0xFFFFFFFFFFFFFFFF, 64);
     a.resize(50, false); // dirty last word 
     a.append(&bit_vec![0, 0, 0, 0, 0]);
-    assert!(a[51] == false);
+    assert!(!a[51]);
 }
 
 #[test]

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -1230,3 +1230,22 @@ fn test_bit_vec_chunks_mut_size_hint() {
     assert_eq!(chunks.len(), 4);
     assert_eq!(chunks.count(), 4);
 }
+
+#[test]
+fn test_atomic_flip_release_partial_word() {
+    // Release is a store-only ordering: the residual-word update must be a
+    // single RMW so that any ordering valid for the full-word path is also
+    // valid for a partial last word (len 65 used to panic with
+    // "there is no such thing as a release load").
+    for len in [64, 65] {
+        let mut bv = AtomicBitVec::<Vec<AtomicUsize>>::new(len);
+        bv.set(len - 1, true, Ordering::Relaxed);
+        bv.flip(Ordering::Release);
+        assert!(!bv.get(len - 1, Ordering::Relaxed), "len {len}");
+        assert!(bv.get(0, Ordering::Relaxed), "len {len}");
+        bv.fill(true, Ordering::Release);
+        assert!(bv.get(len - 1, Ordering::Relaxed), "len {len}");
+        bv.fill(false, Ordering::Release);
+        assert!(!bv.get(0, Ordering::Relaxed), "len {len}");
+    }
+}

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -1172,3 +1172,11 @@ fn test_value_ops_u64() {
 fn test_value_ops_usize() {
     test_value_ops_word_type!(usize);
 }
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic(expected = "overflows usize")]
+fn test_get_value_panics_on_bit_range_end_overflow() {
+    let bv: BitVec = BitVec::new(8);
+    bv.get_value(usize::MAX, 1);
+}

--- a/tests/test_bit_vec.rs
+++ b/tests/test_bit_vec.rs
@@ -1194,3 +1194,12 @@ fn test_reserve_exact_panics_on_len_overflow() {
     let mut b = BitVec::<Vec<usize>>::new(1);
     b.reserve_exact(usize::MAX);
 }
+
+#[test]
+#[should_panic(expected = "overflows usize")]
+fn test_unaligned_get_bits_overflow() {
+    let bv = BitVec::<Vec<usize>>::new(64);
+    // pos + width wraps in release without a checked add; the bounds check
+    // must reject it deterministically in both profiles.
+    let _ = bv.get_value_unaligned(usize::MAX, 2);
+}

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -410,3 +410,31 @@ fn test_huffman_empty_distribution() {
     assert_eq!(decoder.decode(0), None);
     assert_eq!(decoder.decode(usize::MAX), None);
 }
+
+#[test]
+fn test_huffman_deep_distribution_escapes() {
+    // A Fibonacci-skewed distribution produces Huffman codewords deeper than
+    // usize::BITS - 2. The unlimited codec must escape the deepest symbols
+    // instead of assigning an unrepresentable codeword, which previously
+    // overflowed the shift in canonical assignment.
+    let num = usize::BITS as u64 + 2;
+    let mut pairs: Vec<(u64, usize)> = Vec::new();
+    let (mut prev, mut cur) = (1usize, 1usize);
+    for i in 0..num {
+        pairs.push((i, prev));
+        let next = prev + cur;
+        prev = cur;
+        cur = next;
+    }
+    let f: HashMap<u64, usize> = pairs.iter().copied().collect();
+    let coder = HuffmanConf::unlimited().build_coder(&f);
+    assert!(
+        coder.escaped_symbols_len() > 0,
+        "deep symbols must be escaped, not assigned an overlong codeword"
+    );
+    assert!(coder.max_codeword_len() <= usize::BITS - 2);
+    let decoder = coder.clone().into_decoder();
+    for (s, _) in &pairs {
+        round_trip(&coder, &decoder, *s);
+    }
+}

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -393,3 +393,20 @@ fn test_huffman_i32_with_negatives() {
         round_trip_generic(&coder, &decoder, s);
     }
 }
+
+#[test]
+fn test_huffman_empty_distribution() {
+    // The Codec contract allows the empty map and promises a degenerate
+    // coder: encoding any symbol reports out-of-table, and decoding any
+    // window value reports no match with both decoding strategies.
+    let freqs: HashMap<u64, usize> = HashMap::new();
+    let coder = HuffmanConf::default().build_coder(&freqs);
+    assert_eq!(coder.encode(0), None);
+    assert_eq!(coder.encode(u64::MAX), None);
+    let mut decoder = coder.into_decoder();
+    assert_eq!(decoder.decode(0), None);
+    assert_eq!(decoder.decode(usize::MAX), None);
+    decoder.branchless(true);
+    assert_eq!(decoder.decode(0), None);
+    assert_eq!(decoder.decode(usize::MAX), None);
+}

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -284,6 +284,40 @@ fn test_huffman_length_limited() {
 }
 
 #[test]
+fn test_huffman_branchless_decode_out_of_range_returns_none() {
+    let f = freqs(&[(10, 7), (20, 3), (30, 1)]);
+    let coder = HuffmanConf::new().build_coder(&f);
+
+    let codeword = coder.encode(10).expect("10 is in the Huffman table");
+    let codeword_len = coder.codeword_len(10);
+    let max_codeword_len = coder.max_codeword_len();
+    let mut value = 0usize;
+    for k in 0..codeword_len {
+        value |= ((codeword >> k) & 1) << (max_codeword_len - 1 - k);
+    }
+
+    let mut branchy_decoder = coder.clone().into_decoder();
+    branchy_decoder.branchless(false);
+    assert!(!branchy_decoder.is_branchless());
+
+    let mut branchless_decoder = coder.into_decoder();
+    branchless_decoder.branchless(true);
+    assert!(branchless_decoder.is_branchless());
+
+    assert_eq!(
+        branchless_decoder.decode(value),
+        branchy_decoder.decode(value)
+    );
+    assert_eq!(branchless_decoder.decode(usize::MAX), None);
+
+    let empty_frequencies: HashMap<u64, usize> = HashMap::new();
+    let empty_coder = HuffmanConf::new().build_coder(&empty_frequencies);
+    let mut empty_decoder = empty_coder.into_decoder();
+    empty_decoder.branchless(true);
+    assert_eq!(empty_decoder.decode(0), None);
+}
+
+#[test]
 fn test_huffman_i8_with_negatives() {
     // Signed i8 values including negatives: -5 (0xFB), -1 (0xFF),
     // 0, 42, 127 (i8::MAX — no longer reserved).

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -136,6 +136,22 @@ fn test_zero_codec() {
 }
 
 #[test]
+#[should_panic(expected = "cannot encode a nonzero value")]
+fn test_zero_codec_rejects_nonzero_symbol() {
+    let freqs: HashMap<u64, usize> = HashMap::new();
+    let coder = <ZeroCodec as Codec<u64>>::build_coder(&ZeroCodec, &freqs);
+    // Encoding a nonzero value violates the ZeroCodec contract (debug_assert).
+    let _ = coder.encode(7);
+}
+
+#[test]
+fn test_zero_codec_encodes_default() {
+    let freqs: HashMap<u64, usize> = HashMap::new();
+    let coder = <ZeroCodec as Codec<u64>>::build_coder(&ZeroCodec, &freqs);
+    assert_eq!(coder.encode(0), Some(0));
+}
+
+#[test]
 fn test_huffman_single_symbol() {
     let f = freqs(&[(42, 100)]);
     let coder = HuffmanConf::new().build_coder(&f);

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -135,6 +135,8 @@ fn test_zero_codec() {
     assert_eq!(out, Some(0));
 }
 
+// The contract is enforced by a debug_assert!, which compiles out in release.
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "cannot encode a nonzero value")]
 fn test_zero_codec_rejects_nonzero_symbol() {

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -167,6 +167,18 @@ fn test_huffman_single_symbol() {
 }
 
 #[test]
+fn test_huffman_single_symbol_branchy_out_of_window_returns_none() {
+    // A single-symbol table (one 1-bit codeword, no escape) defaults to the
+    // branchy strategy; the unused 1-bit window value must decode to `None`,
+    // mirroring the branchless strategy, instead of panicking.
+    let f = freqs(&[(42, 100)]);
+    let decoder = HuffmanConf::new().build_coder(&f).into_decoder();
+    assert!(!decoder.is_branchless());
+    assert_eq!(decoder.decode(0), Some(42));
+    assert_eq!(decoder.decode(1), None);
+}
+
+#[test]
 fn test_huffman_two_symbols() {
     // Regression: with exactly 2 symbols the Moffat-Katajainen
     // second pass range `0..=size-3` would underflow to

--- a/tests/test_comp_int_list.rs
+++ b/tests/test_comp_int_list.rs
@@ -118,3 +118,12 @@ fn test_value_below_min_panics() {
     let values = vec![0usize, 1, 2];
     let _ = CompIntList::new(1, &values);
 }
+
+#[test]
+fn test_validate() {
+    let values = vec![1u64, 5, 10, 1000];
+    let list = CompIntList::new(1, &values);
+    assert!(list.validate().is_ok());
+    let empty = CompIntList::new(0, &Vec::<u64>::new());
+    assert!(empty.validate().is_ok());
+}

--- a/tests/test_dirty_padding.rs
+++ b/tests/test_dirty_padding.rs
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use sux::prelude::*;
+
+const LEN: usize = 130;
+const WORD_BITS: usize = 64;
+const LOGICAL_ONES: [usize; 13] = [0, 1, 5, 31, 32, 63, 64, 65, 70, 95, 126, 127, 129];
+const RANK_PROBES: [usize; 12] = [0, 1, 2, 6, 63, 64, 65, 66, 96, 127, 128, LEN];
+
+fn clean_words() -> Vec<u64> {
+    let mut words = vec![0; LEN.div_ceil(WORD_BITS)];
+    for &pos in &LOGICAL_ONES {
+        words[pos / WORD_BITS] |= 1u64 << (pos % WORD_BITS);
+    }
+    words
+}
+
+fn dirty_words() -> Vec<u64> {
+    let mut words = clean_words();
+    let residual = LEN % WORD_BITS;
+    assert_ne!(residual, 0);
+    words[LEN / WORD_BITS] |= !0u64 << residual;
+    words
+}
+
+fn clean_bit_vec() -> BitVec<Vec<u64>> {
+    // SAFETY: `clean_words` returns exactly `LEN.div_ceil(WORD_BITS)` initialized
+    // 64-bit words, so `LEN` bits fit in the owned backing storage.
+    unsafe { BitVec::from_raw_parts(clean_words(), LEN) }
+}
+
+fn dirty_bit_vec() -> BitVec<Vec<u64>> {
+    // SAFETY: `dirty_words` preserves the same owned backing length as
+    // `clean_words`; only padding bits after `LEN` are set.
+    unsafe { BitVec::from_raw_parts(dirty_words(), LEN) }
+}
+
+fn expected_rank(pos: usize) -> usize {
+    LOGICAL_ONES.iter().filter(|&&one| one < pos).count()
+}
+
+fn assert_rank_answers<R: Rank>(clean: &R, dirty: &R) {
+    assert_eq!(clean.num_ones(), LOGICAL_ONES.len());
+    assert_eq!(dirty.num_ones(), LOGICAL_ONES.len());
+
+    for pos in RANK_PROBES {
+        let expected = expected_rank(pos);
+        assert_eq!(clean.rank(pos), expected, "clean rank({pos})");
+        assert_eq!(dirty.rank(pos), clean.rank(pos), "dirty rank({pos})");
+        assert_eq!(dirty.rank(pos), expected, "dirty rank({pos})");
+    }
+
+    assert_eq!(clean.rank(LEN), LOGICAL_ONES.len());
+    assert_eq!(dirty.rank(LEN), LOGICAL_ONES.len());
+}
+
+fn assert_select_answers<S: Select>(clean: &S, dirty: &S) {
+    assert_eq!(clean.num_ones(), LOGICAL_ONES.len());
+    assert_eq!(dirty.num_ones(), LOGICAL_ONES.len());
+
+    for (rank, &expected) in LOGICAL_ONES.iter().enumerate() {
+        let clean_selected = clean.select(rank);
+        let dirty_selected = dirty.select(rank);
+        let dirty_pos = dirty_selected.unwrap_or(usize::MAX);
+
+        assert_eq!(clean_selected, Some(expected), "clean select({rank})");
+        assert!(
+            dirty_pos < LEN,
+            "dirty select({rank}) returned padding position {dirty_pos}"
+        );
+        assert_eq!(dirty_selected, clean_selected, "dirty select({rank})");
+        assert_eq!(dirty_selected, Some(expected), "dirty select({rank})");
+    }
+
+    assert_eq!(clean.select(LOGICAL_ONES.len()), None);
+    assert_eq!(dirty.select(LOGICAL_ONES.len()), None);
+}
+
+#[test]
+fn test_rank9_ignores_dirty_padding() {
+    let clean = Rank9::new(clean_bit_vec());
+    let dirty = Rank9::new(dirty_bit_vec());
+
+    assert_rank_answers(&clean, &dirty);
+}
+
+#[test]
+fn test_rank_small_ignores_dirty_padding() {
+    let clean = rank_small![u64: 0; clean_bit_vec()];
+    let dirty = rank_small![u64: 0; dirty_bit_vec()];
+
+    assert_rank_answers(&clean, &dirty);
+}
+
+#[test]
+fn test_select9_ignores_dirty_padding() {
+    let clean = Select9::new(Rank9::new(clean_bit_vec()));
+    let dirty = Select9::new(Rank9::new(dirty_bit_vec()));
+
+    assert_rank_answers(&clean, &dirty);
+    assert_select_answers(&clean, &dirty);
+}
+
+#[test]
+fn test_select_adapt_ignores_dirty_padding() {
+    let clean_bits: AddNumBits<_> = clean_bit_vec().into();
+    let dirty_bits: AddNumBits<_> = dirty_bit_vec().into();
+    let clean = SelectAdapt::new(clean_bits);
+    let dirty = SelectAdapt::new(dirty_bits);
+
+    assert_select_answers(&clean, &dirty);
+}
+
+#[test]
+fn test_select_adapt_const_ignores_dirty_padding() {
+    let clean_bits: AddNumBits<_> = clean_bit_vec().into();
+    let dirty_bits: AddNumBits<_> = dirty_bit_vec().into();
+    let clean = SelectAdaptConst::<_, _>::new(clean_bits);
+    let dirty = SelectAdaptConst::<_, _>::new(dirty_bits);
+
+    assert_select_answers(&clean, &dirty);
+}
+
+#[test]
+fn test_select_small_ignores_dirty_padding() {
+    let clean = SelectSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(clean_bit_vec()));
+    let dirty = SelectSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(dirty_bit_vec()));
+
+    assert_rank_answers(&clean, &dirty);
+    assert_select_answers(&clean, &dirty);
+}

--- a/tests/test_dirty_padding.rs
+++ b/tests/test_dirty_padding.rs
@@ -133,3 +133,85 @@ fn test_select_small_ignores_dirty_padding() {
     assert_rank_answers(&clean, &dirty);
     assert_select_answers(&clean, &dirty);
 }
+
+/// Builds a BitVec via safe `push`, then `pop`s down so the backing retains
+/// stale one-bits in words beyond `len().div_ceil(word_bits)`. Bits
+/// `0..keep` are all ones, so `select(r) == Some(r)` and `rank(keep) == keep`.
+fn popped_ones(fill: usize, keep: usize) -> BitVec<Vec<usize>> {
+    let mut b = BitVec::<Vec<usize>>::new(0);
+    for _ in 0..fill {
+        b.push(true);
+    }
+    for _ in 0..fill - keep {
+        b.pop();
+    }
+    assert_eq!(b.len(), keep);
+    assert_eq!(b.count_ones(), keep);
+    b
+}
+
+fn assert_stale_select<S: Select>(s: &S, keep: usize) {
+    assert_eq!(s.num_ones(), keep);
+    for r in 0..keep {
+        assert_eq!(s.select(r), Some(r), "select({r})");
+    }
+    assert_eq!(s.select(keep), None, "select past the last one");
+}
+
+fn assert_stale_rank<R: Rank>(r: &R, keep: usize) {
+    assert_eq!(r.num_ones(), keep);
+    assert_eq!(r.rank(keep), keep);
+    assert_eq!(r.rank(keep / 2), keep / 2);
+}
+
+#[test]
+fn test_rank9_ignores_stale_backing_words() {
+    assert_stale_rank(&Rank9::new(popped_ones(130, 40)), 40);
+}
+
+#[test]
+fn test_rank_small_ignores_stale_backing_words() {
+    assert_stale_rank(&RankSmall::<64, 2, 9, _>::new(popped_ones(130, 40)), 40);
+}
+
+#[test]
+fn test_select9_ignores_stale_backing_words() {
+    // 600 logical ones cross a 512-quantum boundary while the stale backing
+    // holds 1200, so a builder scanning stale words corrupts the inventory.
+    let s = Select9::new(Rank9::new(popped_ones(1200, 600)));
+    assert_stale_rank(&s, 600);
+    assert_stale_select(&s, 600);
+}
+
+#[test]
+fn test_select_adapt_ignores_stale_backing_words() {
+    let bits: AddNumBits<_> = popped_ones(130, 40).into();
+    assert_stale_select(&SelectAdapt::new(bits), 40);
+}
+
+#[test]
+fn test_select_adapt_const_ignores_stale_backing_words() {
+    let bits: AddNumBits<_> = popped_ones(130, 40).into();
+    assert_stale_select(&SelectAdaptConst::<_, _>::new(bits), 40);
+}
+
+#[test]
+fn test_select_small_ignores_stale_backing_words() {
+    let s = SelectSmall::<2, 9, _>::new(RankSmall::<64, 2, 9, _>::new(popped_ones(1200, 600)));
+    assert_stale_rank(&s, 600);
+    assert_stale_select(&s, 600);
+}
+
+#[test]
+fn test_full_word_boundary_ignores_stale_backing_words() {
+    // `len % 64 == 0`: the tail mask is a no-op, so only the logical word
+    // bound protects against the stale third backing word.
+    assert_stale_rank(&Rank9::new(popped_ones(192, 128)), 128);
+
+    let s = Select9::new(Rank9::new(popped_ones(192, 128)));
+    assert_stale_rank(&s, 128);
+    assert_stale_select(&s, 128);
+
+    let bits: AddNumBits<_> = popped_ones(192, 128).into();
+    assert_stale_select(&SelectAdapt::new(bits), 128);
+}

--- a/tests/test_elias_fano.rs
+++ b/tests/test_elias_fano.rs
@@ -45,6 +45,54 @@ fn test_elias_fano_concurrent() -> Result<()> {
 }
 
 #[test]
+#[should_panic(
+    expected = "EliasFanoConcurrentBuilder::set must be called exactly n times before build"
+)]
+fn test_elias_fano_concurrent_build_panics_without_sets() {
+    use sux::dict::elias_fano::EliasFanoConcurrentBuilder;
+
+    EliasFanoConcurrentBuilder::<u64>::new(1, 10u64).build();
+}
+
+#[test]
+#[should_panic(
+    expected = "EliasFanoConcurrentBuilder::set must be called exactly n times before build"
+)]
+fn test_elias_fano_concurrent_build_panics_when_underfilled() {
+    use sux::dict::elias_fano::EliasFanoConcurrentBuilder;
+
+    let builder = EliasFanoConcurrentBuilder::<u64>::new(3, 10u64);
+    // This regression test intentionally violates the historical exact-count
+    // caller obligation by leaving two entries unset. The source-side fix must
+    // turn that under-fill into a checked build-time panic before the builder
+    // scans its bit vectors.
+    unsafe { builder.set(0, 1) };
+    builder.build();
+}
+
+#[test]
+fn test_elias_fano_concurrent_build_fully_populated() -> Result<()> {
+    use sux::dict::elias_fano::EliasFanoConcurrentBuilder;
+
+    let values = [0u64, 2, 8, 10];
+    let builder = EliasFanoConcurrentBuilder::new(values.len(), 10u64);
+    for (index, value) in values.iter().copied().enumerate() {
+        // SAFETY: each enumerated index is distinct and less than n, and the
+        // `values` array is sorted with every element at most u = 10.
+        unsafe { builder.set(index, value) };
+    }
+
+    let ef = builder.build_with_seq();
+    assert_eq!(ef.len(), values.len());
+    assert_eq!(ef.get(0), 0);
+    assert_eq!(ef.get(1), 2);
+    assert_eq!(ef.get(2), 8);
+    assert_eq!(ef.get(3), 10);
+
+    Ok(())
+}
+
+#[test]
 fn test_elias_fano() -> Result<()> {
     let mut rng = SmallRng::seed_from_u64(0);
     for (n, u) in [

--- a/tests/test_elias_fano.rs
+++ b/tests/test_elias_fano.rs
@@ -51,7 +51,7 @@ fn test_elias_fano_concurrent() -> Result<()> {
 fn test_elias_fano_concurrent_build_panics_without_sets() {
     use sux::dict::elias_fano::EliasFanoConcurrentBuilder;
 
-    EliasFanoConcurrentBuilder::<u64>::new(1, 10u64).build();
+    let _ = EliasFanoConcurrentBuilder::<u64>::new(1, 10u64).build();
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_elias_fano_concurrent_build_panics_when_underfilled() {
     // turn that under-fill into a checked build-time panic before the builder
     // scans its bit vectors.
     unsafe { builder.set(0, 1) };
-    builder.build();
+    let _ = builder.build();
 }
 
 #[test]

--- a/tests/test_elias_fano.rs
+++ b/tests/test_elias_fano.rs
@@ -1391,3 +1391,29 @@ fn test_pred_beyond_last_value() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_into_iter_back_from_boundaries() {
+    use sux::traits::iter::IntoBackIteratorFrom;
+    let mut efb = EliasFanoBuilder::new(4, 10);
+    for v in [0usize, 2, 8, 10] {
+        efb.push(v);
+    }
+    let ef = efb.build_with_seq();
+    // Starting from the last position yields all elements in reverse.
+    let back: Vec<_> = (&ef).into_iter_back_from(3).collect();
+    assert_eq!(back, vec![10, 8, 2, 0]);
+}
+
+#[test]
+#[should_panic(expected = "position overflow")]
+fn test_into_iter_back_from_overflow() {
+    use sux::traits::iter::IntoBackIteratorFrom;
+    let mut efb = EliasFanoBuilder::new(2, 10);
+    efb.push(1usize);
+    efb.push(10);
+    let ef = efb.build_with_seq();
+    // usize::MAX + 1 used to wrap in release, silently yielding an empty
+    // iterator; it must panic deterministically in both profiles.
+    let _ = (&ef).into_iter_back_from(usize::MAX);
+}

--- a/tests/test_fair_chunks.rs
+++ b/tests/test_fair_chunks.rs
@@ -202,3 +202,18 @@ fn test_fair_chunks_uniform_weights() {
     assert_eq!(chunks[0].start, 0);
     assert_eq!(chunks.last().unwrap().end, 10);
 }
+
+#[test]
+fn test_fair_chunks_size_hint() {
+    let cwf = [0u64, 10, 20, 30, 40];
+    let mut efb = EliasFanoBuilder::new(cwf.len(), *cwf.last().unwrap());
+    efb.extend(cwf.iter().copied());
+    let ef = efb.build_with_seq_and_dict();
+    let mut chunks = FairChunks::new(20, &ef);
+    let (lo, hi) = chunks.size_hint();
+    assert!(lo >= 1, "nonempty iterator must report a nonzero lower bound");
+    assert_eq!(hi, Some(4));
+    let n = chunks.by_ref().count();
+    assert!(lo <= n && n <= 4);
+    assert_eq!(chunks.size_hint(), (0, Some(0)));
+}

--- a/tests/test_fair_chunks.rs
+++ b/tests/test_fair_chunks.rs
@@ -31,7 +31,9 @@ fn test_fair_chunks_new_with() {
     let mut efb = EliasFanoBuilder::new(cwf.len(), *cwf.last().unwrap());
     efb.extend(cwf.iter().copied());
     let ef = efb.build_with_dict();
-    let chunks: Vec<_> = FairChunks::new_with(50, &ef, 4, 100).collect();
+    // SAFETY: cwf is nondecreasing, 4 is one less than cwf.len(), and 100 is
+    // the last element of cwf.
+    let chunks: Vec<_> = unsafe { FairChunks::new_with(50, &ef, 4, 100) }.collect();
     assert!(!chunks.is_empty());
     assert_eq!(chunks[0].start, 0);
     assert_eq!(chunks.last().unwrap().end, 4);

--- a/tests/test_fair_chunks.rs
+++ b/tests/test_fair_chunks.rs
@@ -45,8 +45,51 @@ fn test_fair_chunks_single_element() {
     efb.extend(cwf.iter().copied());
     let ef = efb.build_with_seq_and_dict();
     let chunks: Vec<_> = FairChunks::new(50, &ef).collect();
-    // Returns 0..1 (the element) then 1..1 (empty final chunk since we haven't exhausted target_weight)
-    assert_eq!(chunks, vec![0..1, 1..1]);
+    // Returns only the single non-empty element chunk.
+    assert_eq!(chunks, vec![0..1]);
+}
+
+#[test]
+fn test_fair_chunks_u64_max_scale_weights_terminate() {
+    let cwf = [0u64, u64::MAX - 10, u64::MAX - 5, u64::MAX];
+    let mut efb = EliasFanoBuilder::new(cwf.len(), *cwf.last().unwrap());
+    efb.extend(cwf.iter().copied());
+    let ef = efb.build_with_seq_and_dict();
+
+    let num_weights = cwf.len() - 1;
+    let mut chunks = FairChunks::new(u64::MAX - 9, &ef);
+    let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
+    let mut terminated = false;
+
+    for _ in 0..=num_weights {
+        let Some(range) = chunks.next() else {
+            terminated = true;
+            break;
+        };
+
+        assert!(
+            range.start < range.end,
+            "FairChunks yielded an empty or backwards range: {range:?}"
+        );
+
+        if let Some(prev) = ranges.last() {
+            assert_eq!(
+                prev.end, range.start,
+                "FairChunks yielded non-contiguous ranges: {prev:?} then {range:?}"
+            );
+        } else {
+            assert_eq!(range.start, 0);
+        }
+
+        ranges.push(range);
+    }
+
+    assert!(
+        terminated,
+        "FairChunks did not terminate within {} chunks",
+        num_weights + 1
+    );
+    assert_eq!(ranges, vec![0..2, 2..3]);
 }
 
 #[test]

--- a/tests/test_fair_chunks.rs
+++ b/tests/test_fair_chunks.rs
@@ -213,7 +213,10 @@ fn test_fair_chunks_size_hint() {
     let ef = efb.build_with_seq_and_dict();
     let mut chunks = FairChunks::new(20, &ef);
     let (lo, hi) = chunks.size_hint();
-    assert!(lo >= 1, "nonempty iterator must report a nonzero lower bound");
+    assert!(
+        lo >= 1,
+        "nonempty iterator must report a nonzero lower bound"
+    );
     assert_eq!(hi, Some(4));
     let n = chunks.by_ref().count();
     assert!(lo <= n && n <= 4);

--- a/tests/test_jacobson.rs
+++ b/tests/test_jacobson.rs
@@ -1,4 +1,5 @@
 use sux::bal_paren::jacobson::JacobsonBalParen;
+use sux::bit_vec;
 use sux::bits::{BitFieldVec, BitVec};
 use sux::list::prefix_sum_int_list::PrefixSumIntList;
 use sux::prelude::BalParen;
@@ -72,12 +73,58 @@ fn test_small_patterns() {
     }
 }
 
-/* TODO
 #[test]
+#[should_panic(expected = "Unbalanced parentheses")]
 fn test_wrong_paren_count() {
     let _ = JacobsonBalParen::new(from_pattern("()("));
 }
-*/
+
+#[test]
+#[should_panic(expected = "Unbalanced parentheses")]
+fn test_unbalanced_single_open_panics() {
+    let _ = JacobsonBalParen::new(bit_vec![1]);
+}
+
+#[test]
+#[should_panic(expected = "Unbalanced parentheses")]
+fn test_unbalanced_two_opens_panics() {
+    let _ = JacobsonBalParen::new(bit_vec![1, 1]);
+}
+
+#[test]
+#[should_panic(expected = "Unbalanced parentheses")]
+fn test_unbalanced_missing_close_panics() {
+    let _ = JacobsonBalParen::new(bit_vec![1, 1, 0]);
+}
+
+#[test]
+#[should_panic(expected = "Unbalanced parentheses")]
+fn test_unbalanced_extra_close_panics() {
+    let _ = JacobsonBalParen::new(bit_vec![1, 0, 0]);
+}
+
+#[test]
+fn test_find_close_non_word_multiple_length() {
+    let pattern = format!("{}(())", "()".repeat(31));
+    let paren = from_pattern(&pattern);
+    let bp = JacobsonBalParen::new(&paren);
+    let len = pattern.len();
+    assert_eq!(len, 66);
+
+    for (open, expected_close) in [(0, 1), (62, 65), (63, 64)] {
+        match bp.find_close(open) {
+            Some(close) => {
+                assert!(
+                    close < len,
+                    "find_close({open}) returned {close} outside len {len}"
+                );
+                assert_eq!(pattern.as_bytes()[close], b')');
+                assert_eq!(close, expected_close, "find_close({open}) failed");
+            }
+            None => panic!("find_close({open}) returned None"),
+        }
+    }
+}
 
 #[test]
 fn test_cross_word_boundary() {

--- a/tests/test_lcp2_mmphf.rs
+++ b/tests/test_lcp2_mmphf.rs
@@ -251,3 +251,22 @@ fn test_absent_keys_do_not_panic() -> Result<()> {
     assert!(checked > 0);
     Ok(())
 }
+
+/// A common prefix longer than 65535 bits must not wrap the stored LCP length.
+/// On 64-bit `LcpLen` is already u32, so this is a smoke test here; on 32-bit
+/// (i686 CI) it fails before the u16 -> u32 widening.
+#[test]
+fn test_long_common_prefix_str() -> Result<()> {
+    // 8200 bytes = 65600 bits of shared prefix, then a differing byte.
+    let prefix = "a".repeat(8200);
+    let a = format!("{prefix}0");
+    let b = format!("{prefix}1");
+    let mut keys = vec![a.as_str(), b.as_str()];
+    keys.sort();
+    let func: Lcp2MmphfStr = Lcp2MmphfStr::try_new(keys_lender(&keys), keys.len(), no_logging![])?;
+    let func = func.try_into_unaligned().unwrap();
+    for (i, key) in keys.iter().enumerate() {
+        assert_eq!(func.get(key), i, "long-prefix key at position {i}");
+    }
+    Ok(())
+}

--- a/tests/test_lcp2_mmphf.rs
+++ b/tests/test_lcp2_mmphf.rs
@@ -221,3 +221,33 @@ fn test_par_slice_u8() -> Result<()> {
     }
     Ok(())
 }
+
+/// Querying absent keys must never index the `remap` table out of bounds. The
+/// first VFunc can return any frequent-LCP index in `[0, escape)`, but
+/// construction previously sized `remap` to only the frequent lengths, so an
+/// absent key landing in `[num_freq, escape)` panicked in safe `get`.
+#[test]
+fn test_absent_keys_do_not_panic() -> Result<()> {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut keys: Vec<u64> = (0..2000).map(|_| rng.random::<u64>()).collect();
+    keys.sort();
+    keys.dedup();
+    let n = keys.len();
+    let func = Lcp2MmphfInt::<u64>::try_new(FromSlice::new(&keys), n, no_logging![])?
+        .try_into_unaligned()
+        .unwrap();
+    let present: std::collections::HashSet<u64> = keys.iter().copied().collect();
+    let mut probe = SmallRng::seed_from_u64(12345);
+    let mut checked = 0u64;
+    for _ in 0..100_000 {
+        let k = probe.random::<u64>();
+        if present.contains(&k) {
+            continue;
+        }
+        // The result is arbitrary for an absent key, but it must not panic.
+        std::hint::black_box(func.get(k));
+        checked += 1;
+    }
+    assert!(checked > 0);
+    Ok(())
+}

--- a/tests/test_lcp2_mmphf.rs
+++ b/tests/test_lcp2_mmphf.rs
@@ -270,3 +270,13 @@ fn test_long_common_prefix_str() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn test_key_count_mismatch() {
+    // Sorted keys but n larger than the actual count: the constructor must
+    // return Err (the count assert is now a recoverable error), not panic.
+    let keys: Vec<u64> = vec![100, 200];
+    let result: Result<Lcp2MmphfInt<u64>> =
+        Lcp2MmphfInt::try_new(FromSlice::new(&keys), 3, no_logging![]);
+    assert!(result.is_err());
+}

--- a/tests/test_lcp_mmphf.rs
+++ b/tests/test_lcp_mmphf.rs
@@ -331,3 +331,13 @@ fn test_signed_i64_random_1000() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn test_key_count_mismatch() {
+    // Sorted keys but n larger than the actual count: the constructor must
+    // return Err (the count assert is now a recoverable error), not panic.
+    let keys: Vec<u64> = vec![100, 200];
+    let result: Result<LcpMmphfInt<u64>> =
+        LcpMmphfInt::try_new(FromSlice::new(&keys), 3, no_logging![]);
+    assert!(result.is_err());
+}

--- a/tests/test_lcp_mmphf.rs
+++ b/tests/test_lcp_mmphf.rs
@@ -122,6 +122,21 @@ fn test_diverse_keys() -> Result<()> {
 }
 
 #[test]
+fn test_parallel_sharded_str_preserves_store() -> Result<()> {
+    let keys: Vec<String> = (0..100_000).map(|i| format!("key_{i:06}")).collect();
+    let refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+
+    let func = <LcpMmphfStr>::try_par_new(&refs, no_logging![])?;
+    let func = func.try_into_unaligned()?;
+
+    for (i, &key) in refs.iter().enumerate() {
+        assert_eq!(func.get(key), i, "key {key:?} at position {i}");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_unsorted_error() {
     let keys = vec!["beta", "alpha"];
     let result: Result<LcpMmphfStr> = LcpMmphfStr::try_new(keys_lender(&keys), 2, no_logging![]);

--- a/tests/test_lcp_mmphf.rs
+++ b/tests/test_lcp_mmphf.rs
@@ -341,3 +341,17 @@ fn test_key_count_mismatch() {
         LcpMmphfInt::try_new(FromSlice::new(&keys), 3, no_logging![]);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_absent_key_no_panic() {
+    // Absent-key queries decode an arbitrary packed value; the decoded LCP
+    // length must be clamped so IntBitPrefix::new never overflows (which used
+    // to panic in debug for ~half of all absent keys on narrow key types).
+    let keys: Vec<u8> = vec![10, 20, 30, 40, 50];
+    let func: LcpMmphfInt<u8> =
+        LcpMmphfInt::try_new(FromSlice::new(&keys), keys.len(), no_logging![]).unwrap();
+    // Query every possible u8, most of which are absent. Must not panic.
+    for k in 0u8..=255 {
+        let _ = func.get(k);
+    }
+}

--- a/tests/test_mapped_rear_coded_list.rs
+++ b/tests/test_mapped_rear_coded_list.rs
@@ -553,3 +553,31 @@ fn test_single_element() {
     assert_eq!(mrcl.get(0), "hello");
     assert_eq!(mrcl.iter().collect::<Vec<_>>(), vec!["hello".to_string()]);
 }
+
+#[test]
+fn test_validate() {
+    use sux::dict::MappedRearCodedListStr;
+
+    fn make_list() -> sux::dict::RearCodedListStr<true> {
+        let mut builder = RearCodedListBuilder::<str, true>::new(2);
+        for s in ["a", "b", "c"] {
+            builder.push(s);
+        }
+        builder.build()
+    }
+    fn make_map(values: [usize; 3]) -> BitFieldVec<Box<[usize]>> {
+        let mut map = BitFieldVec::<Vec<usize>>::new(2, 0);
+        for v in values {
+            map.push(v);
+        }
+        map.into()
+    }
+
+    // Valid permutation.
+    let mapped = MappedRearCodedListStr::from_parts(make_list(), make_map([2, 0, 1]));
+    assert!(mapped.validate().is_ok());
+
+    // Out-of-range mapping entry: 3 >= len.
+    let mapped = MappedRearCodedListStr::from_parts(make_list(), make_map([2, 0, 3]));
+    assert!(mapped.validate().is_err());
+}

--- a/tests/test_mapped_rear_coded_list.rs
+++ b/tests/test_mapped_rear_coded_list.rs
@@ -440,6 +440,23 @@ fn test_lender_from_bytes() {
 }
 
 #[test]
+fn test_lender_from_len_is_empty() {
+    let mrcl = build_test_mrcl_str();
+    let mut lender = mrcl.lender_from(mrcl.len());
+
+    assert_eq!(ExactSizeLender::len(&lender), 0);
+    assert!(lender.next().is_none());
+    assert!(mrcl.iter_from(mrcl.len()).next().is_none());
+}
+
+#[test]
+#[should_panic(expected = "Index out of bounds")]
+fn test_lender_from_past_len_panics() {
+    let mrcl = build_test_mrcl_str();
+    let _lender = mrcl.lender_from(mrcl.len() + 1);
+}
+
+#[test]
 fn test_lender_exact_size() {
     let mrcl = build_test_mrcl_str();
     let lender = mrcl.lender();

--- a/tests/test_partial_array.rs
+++ b/tests/test_partial_array.rs
@@ -314,3 +314,29 @@ fn test_serialize() {
         assert_eq!(array.get(i), array2.get(i), "Mismatch at index {i}");
     }
 }
+
+#[test]
+fn test_validate() {
+    // Dense.
+    let mut builder = partial_array::new_dense(100);
+    builder.set(1, "a");
+    builder.set(50, "b");
+    let dense = builder.build();
+    assert!(dense.validate().is_ok());
+
+    // Sparse.
+    let mut builder = partial_array::new_sparse(100, 2);
+    builder.set(1, "a");
+    builder.set(50, "b");
+    let sparse = builder.build();
+    assert!(sparse.validate().is_ok());
+
+    // Empty variants.
+    assert!(partial_array::new_dense::<u8>(0).build().validate().is_ok());
+    assert!(
+        partial_array::new_sparse::<u8>(0, 0)
+            .build()
+            .validate()
+            .is_ok()
+    );
+}

--- a/tests/test_partial_array.rs
+++ b/tests/test_partial_array.rs
@@ -89,6 +89,29 @@ fn test_replacement_dense() {
 }
 
 #[test]
+#[should_panic(expected = "Too many values")]
+fn test_sparse_builder_too_many_values() {
+    let mut builder = partial_array::new_sparse(10, 1);
+
+    builder.set(2, "first");
+    builder.set(5, "second");
+}
+
+#[test]
+fn test_sparse_builder_exact_capacity() {
+    let mut builder = partial_array::new_sparse(10, 1);
+
+    builder.set(2, "only");
+
+    let array = builder.build();
+
+    assert_eq!(array.len(), 10);
+    assert_eq!(array.num_values(), 1);
+    assert_eq!(array.get(2), Some(&"only"));
+    assert_eq!(array.get(5), None);
+}
+
+#[test]
 #[should_panic(expected = "Index out of bounds: 10 >= 10")]
 fn test_builder_bounds_check_sparse() {
     let mut builder = partial_array::new_sparse::<&str>(10, 1);

--- a/tests/test_prefix_sum_int_list.rs
+++ b/tests/test_prefix_sum_int_list.rs
@@ -1,3 +1,4 @@
+use sux::dict::EliasFanoBuilder;
 use sux::list::prefix_sum_int_list::PrefixSumIntList;
 use value_traits::slices::SliceByValue;
 
@@ -111,6 +112,44 @@ fn test_empty() {
     let vec_list = to_vec_backend(PrefixSumIntList::new(&empty));
     assert_eq!(vec_list.len(), 0);
     assert!(vec_list.is_empty());
+}
+
+// ────────────────────── Elias–Fano conversion ──────────────────────
+
+#[test]
+#[should_panic(expected = "non-empty")]
+fn test_from_empty_elias_fano_panics() {
+    let efb = EliasFanoBuilder::new(0, 0usize);
+    let ef = efb.build_with_seq();
+    let _: PrefixSumIntList<_> = PrefixSumIntList::from(ef);
+}
+
+#[test]
+#[should_panic(expected = "first element")]
+fn test_from_elias_fano_with_nonzero_first_prefix_sum_panics() {
+    let prefix_sums = [2usize, 5, 8];
+    let mut efb = EliasFanoBuilder::new(prefix_sums.len(), *prefix_sums.last().unwrap());
+    efb.extend(prefix_sums);
+    let ef = efb.build_with_seq();
+    let _: PrefixSumIntList<_> = PrefixSumIntList::from(ef);
+}
+
+#[test]
+fn test_from_valid_elias_fano_prefix_sums() {
+    let prefix_sums = [0usize, 3, 4, 8, 8, 13];
+    let values = [3usize, 1, 4, 0, 5];
+    let mut efb = EliasFanoBuilder::new(prefix_sums.len(), *prefix_sums.last().unwrap());
+    efb.extend(prefix_sums);
+    let ef = efb.build_with_seq();
+
+    let list = PrefixSumIntList::from(ef);
+    assert_eq!(list.len(), values.len());
+    for (i, &value) in values.iter().enumerate() {
+        assert_eq!(list.index_value(i), value);
+    }
+    for (i, &prefix_sum) in prefix_sums.iter().enumerate() {
+        assert_eq!(list.prefix_sum(i), prefix_sum);
+    }
 }
 
 // ────────────────────── prefix_sum boundary ──────────────────────

--- a/tests/test_prefix_sum_int_list.rs
+++ b/tests/test_prefix_sum_int_list.rs
@@ -161,3 +161,15 @@ fn test_prefix_sum_out_of_bounds() {
     let list = PrefixSumIntList::new(&values);
     list.prefix_sum(4); // n = 3, max valid is 3
 }
+
+#[test]
+fn test_validate() {
+    let list = PrefixSumIntList::new(&vec![3usize, 1, 4, 1, 5]);
+    assert!(list.validate().is_ok());
+    let empty = PrefixSumIntList::new(&Vec::<usize>::new());
+    assert!(empty.validate().is_ok());
+
+    // A non-monotone or non-zero-based prefix structure must be rejected.
+    let bad = PrefixSumIntList::try_from_prefix_sums(vec![1usize, 3, 2]);
+    assert!(bad.is_err());
+}

--- a/tests/test_rear_coded_list.rs
+++ b/tests/test_rear_coded_list.rs
@@ -343,3 +343,11 @@ fn test_ser_slice() -> anyhow::Result<()> {
     assert_eq!(&buf, &[2u8, 2u8]);
     Ok(())
 }
+
+#[test]
+#[should_panic(expected = "ratio must be positive")]
+fn test_builder_zero_ratio() {
+    // A zero ratio used to be accepted and made the first push divide by
+    // zero; the constructor must reject it with a clear message.
+    let _ = RearCodedListBuilder::<str, true>::new(0);
+}

--- a/tests/test_select_adapt.rs
+++ b/tests/test_select_adapt.rs
@@ -333,3 +333,10 @@ fn test_1_1_billion_bits() {
     }
     assert_eq!(sel.select(3), None);
 }
+
+#[test]
+#[should_panic(expected = "must be less than")]
+fn test_with_inv_oversized_log() {
+    let bits: AddNumBits<_> = BitVec::<Vec<usize>>::new(128).into();
+    let _ = SelectAdapt::<_>::with_inv(bits, usize::BITS as usize, 0);
+}

--- a/tests/test_select_small.rs
+++ b/tests/test_select_small.rs
@@ -368,3 +368,22 @@ mod test_large {
         test_large!(3; 13);
     }
 }
+
+#[test]
+fn test_with_inv_dense_all_ones() {
+    // Dense inventory: the terminal sentinel must be an inventory index.
+    let len = 1024;
+    let bits = BitVec::<Vec<u64>>::with_value(len, true);
+    let sel = SelectSmall::<2, 9, _>::with_inv(RankSmall::<64, 2, 9, _>::new(bits), 1);
+    for k in 0..len {
+        assert_eq!(sel.select(k), Some(k));
+    }
+    assert_eq!(sel.select(len), None);
+}
+
+#[test]
+#[should_panic(expected = "blocks_per_inv must be positive")]
+fn test_with_inv_zero_blocks() {
+    let bits = BitVec::<Vec<u64>>::with_value(64, true);
+    let _ = SelectSmall::<2, 9, _>::with_inv(RankSmall::<64, 2, 9, _>::new(bits), 0);
+}

--- a/tests/test_select_zero_small.rs
+++ b/tests/test_select_zero_small.rs
@@ -368,3 +368,25 @@ mod test_large {
         test_large!(3; 13);
     }
 }
+
+#[test]
+fn test_with_inv_dense_all_zeros() {
+    // blocks_per_inv = 1 produces a dense inventory with many more entries
+    // than backing words, exercising the terminal-sentinel path. The sentinel
+    // must bound an inventory index (inventory.len()), not the backing word
+    // count; the old value misrouted late queries.
+    let len = 1024;
+    let bits = BitVec::<Vec<u64>>::new(len); // all zeros
+    let sel = SelectZeroSmall::<2, 9, _>::with_inv(RankSmall::<64, 2, 9, _>::new(bits), 1);
+    for k in 0..len {
+        assert_eq!(sel.select_zero(k), Some(k));
+    }
+    assert_eq!(sel.select_zero(len), None);
+}
+
+#[test]
+#[should_panic(expected = "blocks_per_inv must be positive")]
+fn test_with_inv_zero_blocks() {
+    let bits = BitVec::<Vec<u64>>::new(64);
+    let _ = SelectZeroSmall::<2, 9, _>::with_inv(RankSmall::<64, 2, 9, _>::new(bits), 0);
+}

--- a/tests/test_signed_lcp_mmphf.rs
+++ b/tests/test_signed_lcp_mmphf.rs
@@ -10,7 +10,7 @@ use dsi_progress_logger::no_logging;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use sux::bits::BitFieldVec;
-use sux::func::{LcpMmphf, LcpMmphfInt, SignedFunc};
+use sux::func::{Lcp2MmphfInt, Lcp2MmphfStr, LcpMmphf, LcpMmphfInt, SignedFunc};
 use sux::traits::TryIntoUnaligned;
 use sux::utils::FromSlice;
 
@@ -244,5 +244,72 @@ fn test_bit_signed_u64_1000() -> Result<()> {
         assert_eq!(func.get(key), Some(i), "key {key} at position {i}");
     }
     assert_eq!(func.get(0), None);
+    Ok(())
+}
+
+// ── Signed Lcp2Mmphf tests ──────────────────────────────────────────
+
+type SignedLcp2MmphfStr = SignedFunc<Lcp2MmphfStr, Box<[u64]>>;
+type SignedLcp2MmphfInt<T> = SignedFunc<Lcp2MmphfInt<T>, Box<[u64]>>;
+type BitSignedLcp2MmphfInt<T> = SignedFunc<Lcp2MmphfInt<T>, BitFieldVec<Box<[usize]>>>;
+
+#[test]
+fn test_lcp2_u64_small() -> Result<()> {
+    let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
+    let func: SignedLcp2MmphfInt<u64> =
+        SignedLcp2MmphfInt::try_new(FromSlice::new(&keys), keys.len(), no_logging![])?;
+    let func = func.try_into_unaligned()?;
+    for (i, &key) in keys.iter().enumerate() {
+        assert_eq!(func.get(key), Some(i), "key {key}");
+    }
+    assert_eq!(func.get(999), None);
+    Ok(())
+}
+
+#[test]
+fn test_lcp2_u64_1000() -> Result<()> {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut keys: Vec<u64> = (0..1000).map(|_| rng.random::<u64>()).collect();
+    keys.sort();
+    keys.dedup();
+    let n = keys.len();
+    let func: SignedLcp2MmphfInt<u64> =
+        SignedLcp2MmphfInt::try_new(FromSlice::new(&keys), n, no_logging![])?;
+    let func = func.try_into_unaligned()?;
+    for (i, &key) in keys.iter().enumerate() {
+        assert_eq!(func.get(key), Some(i), "key {key}");
+    }
+    assert_eq!(func.get(u64::MAX), None);
+    Ok(())
+}
+
+#[test]
+fn test_lcp2_str_small() -> Result<()> {
+    let mut keys = vec![
+        "alpha".to_owned(),
+        "beta".to_owned(),
+        "delta".to_owned(),
+        "gamma".to_owned(),
+    ];
+    keys.sort();
+    let func: SignedLcp2MmphfStr =
+        SignedLcp2MmphfStr::try_new(FromSlice::new(&keys), keys.len(), no_logging![])?;
+    let func = func.try_into_unaligned()?;
+    for (i, key) in keys.iter().enumerate() {
+        assert_eq!(func.get(key.as_str()), Some(i), "key {key}");
+    }
+    assert_eq!(func.get("absent"), None);
+    Ok(())
+}
+
+#[test]
+fn test_lcp2_bit_signed_u64() -> Result<()> {
+    let keys: Vec<u64> = vec![10, 20, 30, 40, 50];
+    let func: BitSignedLcp2MmphfInt<u64> =
+        BitSignedLcp2MmphfInt::try_new(FromSlice::new(&keys), keys.len(), 8, no_logging![])?;
+    let func = func.try_into_unaligned()?;
+    for (i, &key) in keys.iter().enumerate() {
+        assert_eq!(func.get(key), Some(i), "key {key}");
+    }
     Ok(())
 }

--- a/tests/test_signed_vfunc.rs
+++ b/tests/test_signed_vfunc.rs
@@ -81,3 +81,12 @@ fn test_validate() -> Result<()> {
     assert!(func.validate().is_ok());
     Ok(())
 }
+
+#[test]
+fn test_hash_width_zero_errors() {
+    let mut pl = ProgressLogger::default();
+    // hash_width == 0 is invalid; the try_ constructor must return Err, not
+    // panic.
+    let r = MyBitSignedVFunc::try_new(FromCloneableIntoIterator::from(0..10usize), 0, &mut pl);
+    assert!(r.is_err());
+}

--- a/tests/test_signed_vfunc.rs
+++ b/tests/test_signed_vfunc.rs
@@ -71,3 +71,13 @@ fn test_bit_signed_vfunc() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_validate() -> Result<()> {
+    let mut pl = ProgressLogger::default();
+    let n = 1000;
+    let func: MySignedVFunc =
+        MySignedVFunc::try_new(FromCloneableIntoIterator::from(0..n), &mut pl)?;
+    assert!(func.validate().is_ok());
+    Ok(())
+}

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -47,7 +47,9 @@ where
             VBuilder::default().offline(offline).low_mem(low_mem),
             &mut pl,
         )?;
+        assert!(func.validate().is_ok(), "aligned VFunc must validate");
         let func = func.try_into_unaligned().unwrap();
+        assert!(func.validate().is_ok(), "unaligned VFunc must validate");
         pl.start("Querying...");
         for i in 0..n {
             assert_eq!(i, func.get(i));
@@ -114,6 +116,7 @@ where
             VBuilder::default().offline(offline).low_mem(low_mem),
             &mut pl,
         )?;
+        assert!(filter.validate().is_ok(), "VFilter must validate");
         pl.start("Querying (positive)...");
         for i in 0..n {
             assert!(filter.contains(i), "Contains failed for {}", i);

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -231,3 +231,22 @@ fn test_mismatched_keys_and_values() -> Result<()> {
 
     Ok(())
 }
+
+/// The parallel builder does not support offline (disk-based) construction and
+/// must reject it rather than silently ignoring the flag.
+#[test]
+fn test_par_builder_rejects_offline() {
+    let keys: Vec<usize> = (0..1000).collect();
+    let values: Vec<usize> = (0..1000).collect();
+    let result = <VFunc<usize, BitFieldVec<Box<[usize]>>>>::try_par_new_with_builder(
+        &keys,
+        &values,
+        VBuilder::default().offline(true),
+        &mut ProgressLogger::default(),
+    );
+    let err = result.expect_err("parallel builder must reject offline mode instead of ignoring it");
+    assert!(
+        err.to_string().contains("offline"),
+        "expected an offline-rejection error, got: {err}"
+    );
+}

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -254,11 +254,12 @@ fn test_par_builder_rejects_offline() {
     );
 }
 
-/// A non-finite or negative `eps` is rejected up front rather than triggering an
-/// unbounded shard-resizing retry loop.
+/// An `eps` outside the open interval (0, 1) — including NaN and ±∞ — is
+/// rejected up front rather than producing NaN shard sizing or an unbounded
+/// shard-resizing retry loop.
 #[test]
 fn test_builder_rejects_invalid_eps() {
-    for bad in [-1.0_f64, f64::NAN, f64::INFINITY] {
+    for bad in [-1.0_f64, 0.0, 1.0, 1.5, f64::NAN, f64::INFINITY] {
         let result = <VFunc<usize, BitFieldVec<Box<[usize]>>>>::try_new_with_builder(
             FromCloneableIntoIterator::from(0..1000),
             FromCloneableIntoIterator::from(0_usize..),
@@ -267,8 +268,17 @@ fn test_builder_rejects_invalid_eps() {
         );
         let err = result.expect_err("builder must reject invalid eps");
         assert!(
-            err.to_string().contains("must be finite"),
+            err.to_string().contains("eps must be in the open interval"),
             "expected an eps-validation error for {bad}, got: {err}"
         );
     }
+
+    // The default eps stays accepted.
+    <VFunc<usize, BitFieldVec<Box<[usize]>>>>::try_new_with_builder(
+        FromCloneableIntoIterator::from(0..1000),
+        FromCloneableIntoIterator::from(0_usize..),
+        VBuilder::default().eps(0.001),
+        &mut ProgressLogger::default(),
+    )
+    .expect("the default eps must be accepted");
 }

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -250,3 +250,22 @@ fn test_par_builder_rejects_offline() {
         "expected an offline-rejection error, got: {err}"
     );
 }
+
+/// A non-finite or negative `eps` is rejected up front rather than triggering an
+/// unbounded shard-resizing retry loop.
+#[test]
+fn test_builder_rejects_invalid_eps() {
+    for bad in [-1.0_f64, f64::NAN, f64::INFINITY] {
+        let result = <VFunc<usize, BitFieldVec<Box<[usize]>>>>::try_new_with_builder(
+            FromCloneableIntoIterator::from(0..1000),
+            FromCloneableIntoIterator::from(0_usize..),
+            VBuilder::default().eps(bad),
+            &mut ProgressLogger::default(),
+        );
+        let err = result.expect_err("builder must reject invalid eps");
+        assert!(
+            err.to_string().contains("must be finite"),
+            "expected an eps-validation error for {bad}, got: {err}"
+        );
+    }
+}

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -282,3 +282,25 @@ fn test_builder_rejects_invalid_eps() {
     )
     .expect("the default eps must be accepted");
 }
+
+#[test]
+fn test_duplicate_keys_error() {
+    // Two identical keys make every solve attempt fail: the builder must
+    // detect the duplicate and return a DuplicateKey error instead of
+    // reseeding until it panics. check_dups is left at its default (false).
+    let mut pl = ProgressLogger::default();
+    let keys = vec![5usize, 5];
+    let values = vec![0usize, 1];
+    let result = <VFunc<usize, BitFieldVec<Box<[usize]>>, [u64; 2], FuseLge3Shards>>::try_new_with_builder(
+        FromCloneableIntoIterator::from(keys),
+        FromCloneableIntoIterator::from(values),
+        VBuilder::default(),
+        &mut pl,
+    );
+    let err = result.expect_err("duplicate keys must return an error, not panic or loop");
+    assert!(
+        err.downcast_ref::<sux::func::BuildError>()
+            .is_some_and(|e| matches!(e, sux::func::BuildError::DuplicateKey)),
+        "expected a DuplicateKey error, got: {err:#}"
+    );
+}

--- a/tests/test_vfunc.rs
+++ b/tests/test_vfunc.rs
@@ -291,12 +291,13 @@ fn test_duplicate_keys_error() {
     let mut pl = ProgressLogger::default();
     let keys = vec![5usize, 5];
     let values = vec![0usize, 1];
-    let result = <VFunc<usize, BitFieldVec<Box<[usize]>>, [u64; 2], FuseLge3Shards>>::try_new_with_builder(
-        FromCloneableIntoIterator::from(keys),
-        FromCloneableIntoIterator::from(values),
-        VBuilder::default(),
-        &mut pl,
-    );
+    let result =
+        <VFunc<usize, BitFieldVec<Box<[usize]>>, [u64; 2], FuseLge3Shards>>::try_new_with_builder(
+            FromCloneableIntoIterator::from(keys),
+            FromCloneableIntoIterator::from(values),
+            VBuilder::default(),
+            &mut pl,
+        );
     let err = result.expect_err("duplicate keys must return an error, not panic or loop");
     assert!(
         err.downcast_ref::<sux::func::BuildError>()

--- a/tests/test_vfunc2.rs
+++ b/tests/test_vfunc2.rs
@@ -37,3 +37,91 @@ fn test_parallel_sharded_vfunc2_preserves_store() -> Result<()> {
 
     Ok(())
 }
+
+/// Two `u128` values sharing their low 64 bits but differing in the high bits
+/// must be stored distinctly. Before the HybridMap key-truncation fix these
+/// collided on the same flat-array slot, so half the keys returned the wrong
+/// value.
+#[test]
+fn test_vfunc2_wide_u128_values() -> Result<()> {
+    let low: u128 = 5;
+    let high: u128 = (1u128 << 64) | 5; // same low 64 bits as `low`
+    let n = 2000usize;
+    let keys: Vec<u64> = (0..n)
+        .map(u64::try_from)
+        .collect::<std::result::Result<_, _>>()?;
+    let values: Vec<u128> = (0..n)
+        .map(|i| if i % 2 == 0 { low } else { high })
+        .collect();
+
+    let func: VFunc2<u64, BitFieldVec<Box<[u128]>>> =
+        VFunc2::try_par_new(&keys, &values, no_logging![])?;
+
+    for (&key, &expected) in keys.iter().zip(&values) {
+        assert_eq!(func.get(key), expected, "key {key}");
+    }
+    Ok(())
+}
+
+/// A uniform distribution over several wide values (some differing only in
+/// their high bits) builds and queries correctly.
+#[test]
+fn test_vfunc2_uniform_u128() -> Result<()> {
+    let distinct: [u128; 6] = [
+        0,
+        1,
+        1u128 << 64,
+        (1u128 << 64) | 1,
+        1u128 << 100,
+        (1u128 << 100) | 7,
+    ];
+    let n = 5000usize;
+    let keys: Vec<u64> = (0..n)
+        .map(u64::try_from)
+        .collect::<std::result::Result<_, _>>()?;
+    let values: Vec<u128> = (0..n).map(|i| distinct[i % distinct.len()]).collect();
+
+    let func: VFunc2<u64, BitFieldVec<Box<[u128]>>> =
+        VFunc2::try_par_new(&keys, &values, no_logging![])?;
+
+    for (&key, &expected) in keys.iter().zip(&values) {
+        assert_eq!(func.get(key), expected, "key {key}");
+    }
+    Ok(())
+}
+
+/// Build and query VFunc2 over the narrow value backends (`u32` and `u64`),
+/// covering the value widths below `u128`.
+#[test]
+fn test_vfunc2_narrow_value_widths() -> Result<()> {
+    let n = 3000usize;
+    let keys: Vec<u64> = (0..n)
+        .map(u64::try_from)
+        .collect::<std::result::Result<_, _>>()?;
+
+    // u32 backend, skewed values.
+    let v32: Vec<u32> = keys
+        .iter()
+        .map(|&k| {
+            if k % 4 == 0 {
+                1_000_000
+            } else {
+                u32::try_from(k % 7).unwrap()
+            }
+        })
+        .collect();
+    let f32: VFunc2<u64, BitFieldVec<Box<[u32]>>> =
+        VFunc2::try_par_new(&keys, &v32, no_logging![])?;
+    for (&key, &expected) in keys.iter().zip(&v32) {
+        assert_eq!(f32.get(key), expected, "u32 key {key}");
+    }
+
+    // u64 backend, roughly uniform values.
+    let v64: Vec<u64> = keys.iter().map(|&k| (k % 5) * 1_000_000_000).collect();
+    let f64: VFunc2<u64, BitFieldVec<Box<[u64]>>> =
+        VFunc2::try_par_new(&keys, &v64, no_logging![])?;
+    for (&key, &expected) in keys.iter().zip(&v64) {
+        assert_eq!(f64.get(key), expected, "u64 key {key}");
+    }
+    Ok(())
+}

--- a/tests/test_vfunc2.rs
+++ b/tests/test_vfunc2.rs
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#![cfg(feature = "rayon")]
+
+use anyhow::Result;
+use dsi_progress_logger::no_logging;
+use sux::bits::BitFieldVec;
+use sux::func::VFunc2;
+
+const NUM_SHARDED_KEYS: usize = 100_000;
+
+fn vfunc2_value(i: usize) -> usize {
+    if i % 5 == 0 {
+        10_000 + i % 4_093
+    } else {
+        i % 11
+    }
+}
+
+#[test]
+fn test_parallel_sharded_vfunc2_preserves_store() -> Result<()> {
+    let keys: Vec<u64> = (0..NUM_SHARDED_KEYS)
+        .map(u64::try_from)
+        .collect::<std::result::Result<_, _>>()?;
+    let values: Vec<usize> = (0..NUM_SHARDED_KEYS).map(vfunc2_value).collect();
+
+    let func: VFunc2<u64, BitFieldVec<Box<[usize]>>> =
+        VFunc2::try_par_new(&keys, &values, no_logging![])?;
+
+    for (&key, &expected) in keys.iter().zip(&values) {
+        assert_eq!(func.get(key), expected, "key {key}");
+    }
+
+    Ok(())
+}

--- a/tests/test_vfunc2.rs
+++ b/tests/test_vfunc2.rs
@@ -56,6 +56,7 @@ fn test_vfunc2_wide_u128_values() -> Result<()> {
 
     let func: VFunc2<u64, BitFieldVec<Box<[u128]>>> =
         VFunc2::try_par_new(&keys, &values, no_logging![])?;
+    assert!(func.validate().is_ok(), "wide-u128 VFunc2 must validate");
 
     for (&key, &expected) in keys.iter().zip(&values) {
         assert_eq!(func.get(key), expected, "key {key}");


### PR DESCRIPTION
# Summary

Hardening pass over the whole crate plus the 0.16.0 release bump: 54 commits, +2100/-270 across ~60 files. Roughly, the changeset:

- fixes an aliasing-UB in the parallel solver (`&mut` fabricated from a shared `Arc` on the store-preserving path), atomic-ordering decomposition in `AtomicBitFieldVec::set_atomic`, dirty-padding handling in rank/select builders, zero-width `BitFieldVec` backing, checked bit-length arithmetic, `FairChunks` overflow, and lossless `VFunc2` wide-value handling;
- adds `validate()` to `BitFieldVec`, `VFunc`, `VFunc2`, `VFilter`, and `CompVFunc` (plus `ShardEdge::validate`) so structures deserialized from untrusted sources can be checked before the unchecked query paths run;
- validates builder/CLI inputs that previously panicked, looped forever, or silently misbehaved (`eps`, offline mode in the parallel builder, `MaxShardTooBig` retries, key/value count mismatches, `mem_usage` arguments);
- **breaking:** renames `BitVecValueOps::get_value{,_unchecked}` to `get_bits{,_unchecked}` (avoids clashing with the index-based `SliceByValue` methods) and turns `UnalignedConversionError` into a structured `#[non_exhaustive]` enum.

The final 14 commits (`5360df53..4576c3f6`) address the findings of a full pre-merge review of the branch, most notably:

- `Select9`/`SelectAdapt`/`SelectAdaptConst`/`SelectSmall` builders now iterate only the logical words, so a `BitVec` shrunk via safe `pop()`/`resize()` (stale one-bits in backing words past `len().div_ceil(word_bits)`) no longer panics the constructors or indexes padding — with regression tests, including the `len % 64 == 0` boundary;
- `gaussian_elimination` accepts redundant identity pivot rows instead of reporting solvable systems as unsolvable;
- the branchy Huffman decoder returns `None` for out-of-window values (mirroring the branchless strategy) instead of `unreachable!()`;
- the parallel builder skips the max-shard sanity check for hinted builds, mirroring the sequential path, so hinted parallel `CompVFunc` builds cannot spuriously exhaust the new retry cap;
- `eps` is validated to lie in (0, 1) — the ε-cost formulas divide by `ln(1 - eps)`;
- `BitVec::reserve`/`reserve_exact`/`append_value` use checked bit-length arithmetic; oversized byte-key LCPs (> `u32::MAX` bits) are reported as errors; all 15 CLI `try_into_unaligned().unwrap()` sites propagate the structured error instead of panicking.

# ⚠️ Blocked on the epserde 0.13.0 publish

`Cargo.toml` deliberately carries `epserde = { version = "0.13", path = "../epserde-rs/epserde", … }`: 0.13.0 is not yet on crates.io, and since the dependency is optional-but-always-resolved, a pure registry pin would make every build fail at manifest resolution. CI and clean checkouts will not resolve the path dep — merge/publish after epserde 0.13.0 lands, then drop the `path` key (one-line change, see the TODO in `Cargo.toml`).

# Verification

- `cargo build --features cli,epserde,deko,rayon,serde,mmap --all-targets` and `--no-default-features --features mwhc --lib`: clean (against the local epserde 0.13.0 checkout)
- `cargo clippy --features cli,epserde,deko,rayon,serde,mmap --all-targets -- -D warnings`: clean
- `cargo test --release --features cli,epserde,deko,rayon,serde,mmap`: 758 passed / 46 suites
- `cargo test --release … --doc`: 125 passed
- Every post-review fix carries a test that fails on the pre-fix code (the select-builder panics were reproduced via safe `push`/`pop` before the fix)